### PR TITLE
feat: Integrate Mercado Pago payment flow

### DIFF
--- a/src/app/components/pages/pago/pago.component.html
+++ b/src/app/components/pages/pago/pago.component.html
@@ -2,6 +2,10 @@
     <h2>¡Gracias por tu pedido!</h2>
     <p>Tu número de pedido es: <span class="font-semibold">#{{ pedidoId }}</span></p>
     <p>Estado del pedido: <span class="font-semibold">{{ orderStatus }}</span></p>
+
+    <div *ngIf="orderStatus === 'Pago Verificado'" class="payment-success-message">
+      <p>Tu pago ha sido verificado exitosamente.</p>
+    </div>
   
     <div *ngIf="orderStatus !== 'Pago Verificado'">
       <h3>Selecciona tu método de pago:</h3>

--- a/src/app/components/pages/pago/pago.component.spec.ts
+++ b/src/app/components/pages/pago/pago.component.spec.ts
@@ -1,23 +1,217 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, ParamMap } from '@angular/router';
+import { of, Subject, throwError } from 'rxjs';
+import { CommonModule } from '@angular/common'; // PagoComponent is standalone, but good for TestBed consistency if it weren't
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { PagoComponent } from './pago.component';
+import { PagoService } from '../../../../services/pago.service';
+import { PedidoService } from '../../../../services/pedido/pedido.service';
+
+// Mocks
+class MockActivatedRoute {
+  snapshot = {
+    paramMap: convertToParamMap({ id: '1' }) // Default pedidoId for tests
+  };
+  private queryParamsSubject = new Subject<ParamMap>();
+  queryParamMap = this.queryParamsSubject.asObservable();
+
+  setQueryParamMap(params: any) {
+    this.queryParamsSubject.next(convertToParamMap(params));
+  }
+}
+
+class MockPagoService {
+  confirmarPagoMercadoPago = jasmine.createSpy('confirmarPagoMercadoPago').and.returnValue(of({ message: 'Pago confirmado' }));
+}
+
+class MockPedidoService {
+  getOrderStatus = jasmine.createSpy('getOrderStatus').and.returnValue(of({ estado: 'PENDIENTE DE PAGO' }));
+  uploadVoucher = jasmine.createSpy('uploadVoucher').and.returnValue(of({ message: 'Voucher subido' }));
+}
 
 describe('PagoComponent', () => {
   let component: PagoComponent;
   let fixture: ComponentFixture<PagoComponent>;
+  let mockActivatedRoute: MockActivatedRoute;
+  let mockPagoService: MockPagoService;
+  let mockPedidoService: MockPedidoService;
+  let windowSpy: any;
 
   beforeEach(async () => {
+    mockActivatedRoute = new MockActivatedRoute();
+    mockPagoService = new MockPagoService();
+    mockPedidoService = new MockPedidoService();
+
     await TestBed.configureTestingModule({
-      imports: [PagoComponent]
-    })
-    .compileComponents();
+      imports: [
+        PagoComponent, // Component is standalone, so it brings its own CommonModule etc.
+        RouterTestingModule // For routerLink, router-outlet etc. if used, good to have
+      ],
+      providers: [
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: PagoService, useValue: mockPagoService },
+        { provide: PedidoService, useValue: mockPedidoService }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(PagoComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    // fixture.detectChanges(); // We'll call this in each test or after setting queryParams
+
+    // Spy on window.alert
+    spyOn(window, 'alert').and.stub();
+    // Spy on console.log and console.error
+    spyOn(console, 'log').and.stub();
+    spyOn(console, 'error').and.stub();
+
+    // For window.location.href
+    // Store the original window.location
+    const originalLocation = window.location;
+    // Create a spy for window.location.href
+    windowSpy = spyOnProperty(window, 'location', 'get').and.returnValue(
+      // @ts-ignore
+      { ...originalLocation, href: '' } 
+    );
+    // We need to be able to set href, so we also spy on the 'set' accessor if possible,
+    // or re-assign `window.location` if necessary and possible in test env.
+    // For simplicity here, we'll check the value assigned to `window.location.href`.
+    // A more robust way is to use a spy object for location.
   });
 
   it('should create', () => {
+    fixture.detectChanges(); // Initial binding
     expect(component).toBeTruthy();
   });
+
+  it('should fetch order status on init', () => {
+    fixture.detectChanges();
+    expect(mockPedidoService.getOrderStatus).toHaveBeenCalledWith(1); // pedidoId is '1' from ActivatedRoute mock
+    expect(component.orderStatus).toBe('PENDIENTE DE PAGO');
+  });
+
+  describe('ngOnInit - Mercado Pago Callback', () => {
+    it('should confirm payment if collection_status is "approved" and external_reference matches pedidoId', fakeAsync(() => {
+      mockActivatedRoute.setQueryParamMap({
+        status: 'approved', // General status, can be used
+        collection_status: 'approved', // Specific status for Mercado Pago
+        external_reference: '1'
+      });
+      fixture.detectChanges(); // Trigger ngOnInit and queryParamMap subscription
+      tick(); // Process observables
+
+      expect(mockPagoService.confirmarPagoMercadoPago).toHaveBeenCalledWith(1);
+      expect(component.orderStatus).toBe('Pago Verificado');
+      expect(window.alert).toHaveBeenCalledWith('¡Pago con Mercado Pago confirmado exitosamente! Estado del pedido actualizado a Pago Verificado.');
+      expect(mockPedidoService.getOrderStatus).toHaveBeenCalledTimes(2); // Initial + after MP confirmation
+    }));
+
+    it('should handle error if confirmarPagoMercadoPago fails', fakeAsync(() => {
+      mockPagoService.confirmarPagoMercadoPago.and.returnValue(throwError(() => new Error('Confirmation Failed')));
+      mockActivatedRoute.setQueryParamMap({
+        collection_status: 'approved',
+        external_reference: '1'
+      });
+      fixture.detectChanges();
+      tick();
+
+      expect(mockPagoService.confirmarPagoMercadoPago).toHaveBeenCalledWith(1);
+      expect(window.alert).toHaveBeenCalledWith('Error al confirmar el pago con Mercado Pago. Por favor, contacta a soporte.');
+      expect(component.orderStatus).not.toBe('Pago Verificado'); // or check it remains initial/fetched one
+      expect(mockPedidoService.getOrderStatus).toHaveBeenCalledTimes(2); // Initial + after MP error
+    }));
+
+    it('should alert and fetch status if payment status is not "approved" but external_reference matches', fakeAsync(() => {
+      mockActivatedRoute.setQueryParamMap({
+        status: 'pending', // General status from MP
+        collection_status: 'pending', // More specific status
+        external_reference: '1'
+      });
+      fixture.detectChanges();
+      tick();
+
+      expect(mockPagoService.confirmarPagoMercadoPago).not.toHaveBeenCalled();
+      expect(window.alert).toHaveBeenCalledWith('El pago con Mercado Pago está pending.');
+      expect(mockPedidoService.getOrderStatus).toHaveBeenCalledTimes(2); // Initial + after MP pending
+    }));
+    
+    it('should NOT confirm payment if external_reference does not match pedidoId', fakeAsync(() => {
+      mockActivatedRoute.setQueryParamMap({
+        collection_status: 'approved',
+        external_reference: '2' // Mismatched ID
+      });
+      fixture.detectChanges();
+      tick();
+
+      expect(mockPagoService.confirmarPagoMercadoPago).not.toHaveBeenCalled();
+      expect(component.orderStatus).toBe('PENDIENTE DE PAGO'); // Stays initial
+    }));
+
+    it('should NOT confirm payment if collection_status is not "approved"', fakeAsync(() => {
+      mockActivatedRoute.setQueryParamMap({
+        collection_status: 'rejected',
+        external_reference: '1'
+      });
+      fixture.detectChanges();
+      tick();
+
+      expect(mockPagoService.confirmarPagoMercadoPago).not.toHaveBeenCalled();
+       // The component logic also checks for 'status' if 'collection_status' isn't 'approved'.
+       // If status is also not 'approved' (e.g. 'rejected'), it alerts.
+      expect(window.alert).toHaveBeenCalledWith('El pago con Mercado Pago está rejected.');
+      expect(component.orderStatus).toBe('PENDIENTE DE PAGO'); // Stays initial
+    }));
+
+    it('should not call confirmarPagoMercadoPago if no relevant query params are present', fakeAsync(() => {
+      mockActivatedRoute.setQueryParamMap({}); // No MP params
+      fixture.detectChanges();
+      tick();
+
+      expect(mockPagoService.confirmarPagoMercadoPago).not.toHaveBeenCalled();
+      expect(component.orderStatus).toBe('PENDIENTE DE PAGO');
+    }));
+  });
+
+  describe('pagarConMercadoPago', () => {
+    it('should redirect to the correct Mercado Pago URL', () => {
+      component.pedidoId = 5; // Set a pedidoId for the component instance
+      fixture.detectChanges();
+      
+      component.pagarConMercadoPago();
+      // @ts-ignore
+      expect(window.location.href).toBe('http://localhost:8080/api/mercado-pago/pagar/5');
+    });
+  });
+  
+  // Example test for onVoucherSelected and uploadVoucher (not part of this subtask but good for completeness)
+  describe('Voucher Upload', () => {
+    it('onVoucherSelected should set selectedFile', () => {
+      const mockFile = new File([''], 'voucher.jpg', { type: 'image/jpeg' });
+      const event = { target: { files: [mockFile] } };
+      component.onVoucherSelected(event);
+      expect(component.selectedFile).toBe(mockFile);
+    });
+
+    it('uploadVoucher should call pedidoService.uploadVoucher if a file is selected', () => {
+      const mockFile = new File([''], 'voucher.jpg', { type: 'image/jpeg' });
+      component.selectedFile = mockFile;
+      component.pedidoId = 1;
+      mockPedidoService.uploadVoucher.and.returnValue(of({ message: 'Voucher uploaded successfully' }));
+      
+      component.uploadVoucher();
+      
+      expect(mockPedidoService.uploadVoucher).toHaveBeenCalledWith(1, mockFile);
+      expect(window.alert).toHaveBeenCalledWith('Voucher subido exitosamente. El estado del pedido se actualizará en breve.');
+      expect(component.orderStatus).toBe('Confirmación de Pago Enviada'); // Temporary status
+      expect(mockPedidoService.getOrderStatus).toHaveBeenCalledTimes(1); // Assuming initial fetch + this one
+    });
+
+    it('uploadVoucher should alert if no file is selected', () => {
+      component.selectedFile = null;
+      component.uploadVoucher();
+      expect(window.alert).toHaveBeenCalledWith('Por favor, selecciona un archivo de voucher.');
+      expect(mockPedidoService.uploadVoucher).not.toHaveBeenCalled();
+    });
+  });
+
 });

--- a/src/app/components/pages/pago/pago.component.ts
+++ b/src/app/components/pages/pago/pago.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { RouterModule, ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { PedidoService } from '../../../../services/pedido/pedido.service';
+import { PagoService } from '../../../../services/pago.service'; // Added PagoService import
 
 @Component({
   selector: 'app-pago',
@@ -15,11 +16,52 @@ export class PagoComponent implements OnInit {
   selectedFile: File | null = null;
   orderStatus: string = 'PENDIENTE DE PAGO'; // Default status
 
-  constructor(private route: ActivatedRoute, private pedidoService: PedidoService) {}
+  constructor(
+    private route: ActivatedRoute,
+    private pedidoService: PedidoService,
+    private pagoService: PagoService // Injected PagoService
+  ) {}
 
   ngOnInit(): void {
+    // Get pedidoId from route params
     this.pedidoId = Number(this.route.snapshot.paramMap.get('id'));
-    this.fetchOrderStatus();
+    this.fetchOrderStatus(); // Initial status fetch
+
+    // Check for Mercado Pago callback query parameters
+    this.route.queryParamMap.subscribe(params => {
+      const paymentStatus = params.get('status'); // Mercado Pago uses 'status'
+      const externalReference = params.get('external_reference');
+      const collectionStatus = params.get('collection_status'); // More specific status
+
+      console.log('Mercado Pago callback params:', { paymentStatus, externalReference, collectionStatus, pedidoId: this.pedidoId });
+
+      // It's common for external_reference to be the order ID.
+      // Mercado Pago status 'approved' usually means success.
+      if (collectionStatus === 'approved' && externalReference && Number(externalReference) === this.pedidoId) {
+        console.log(`Attempting to confirm Mercado Pago payment for order ${this.pedidoId}`);
+        this.pagoService.confirmarPagoMercadoPago(this.pedidoId).subscribe(
+          response => {
+            console.log('Payment confirmation successful:', response);
+            this.orderStatus = 'Pago Verificado';
+            alert('¡Pago con Mercado Pago confirmado exitosamente! Estado del pedido actualizado a Pago Verificado.');
+            // Optionally, re-fetch to ensure consistency, though direct update is good for UI
+            this.fetchOrderStatus(); 
+          },
+          error => {
+            console.error('Error confirming Mercado Pago payment:', error);
+            alert('Error al confirmar el pago con Mercado Pago. Por favor, contacta a soporte.');
+            // Potentially fetch status again to see if it was processed despite error, or leave as is
+            this.fetchOrderStatus();
+          }
+        );
+      } else if (paymentStatus && paymentStatus !== 'approved' && externalReference && Number(externalReference) === this.pedidoId) {
+        // Handle cases like 'pending', 'rejected', etc.
+        console.log(`Mercado Pago payment status for order ${this.pedidoId}: ${paymentStatus}`);
+        alert(`El pago con Mercado Pago está ${paymentStatus}.`);
+        // We might still want to fetch the order status from our backend
+        this.fetchOrderStatus();
+      }
+    });
   }
 
   fetchOrderStatus(): void {

--- a/src/app/services/pago.service.spec.ts
+++ b/src/app/services/pago.service.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { PagoService } from './pago.service';
+
+describe('PagoService', () => {
+  let service: PagoService;
+  let httpMock: HttpTestingController;
+  let apiUrl = 'http://localhost:8080/api/orders';
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PagoService]
+    });
+    service = TestBed.inject(PagoService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify(); // Make sure that there are no outstanding requests.
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('confirmarPagoMercadoPago', () => {
+    it('should make a POST request to the correct URL and return data on success', () => {
+      const pedidoId = 123;
+      const mockResponse = { status: 'success', message: 'Pago confirmado' };
+
+      service.confirmarPagoMercadoPago(pedidoId).subscribe(response => {
+        expect(response).toEqual(mockResponse);
+      });
+
+      const req = httpMock.expectOne(`${apiUrl}/${pedidoId}/confirmar-pago-mercadopago`);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({}); // Expecting an empty body as per implementation
+      req.flush(mockResponse);
+    });
+
+    it('should handle HTTP errors correctly', () => {
+      const pedidoId = 456;
+      const errorMessage = 'Error confirming payment';
+      const mockErrorResponse = { status: 500, statusText: 'Server Error' };
+
+      service.confirmarPagoMercadoPago(pedidoId).subscribe(
+        response => fail('should have failed with an error'),
+        error => {
+          expect(error.status).toBe(500);
+          expect(error.statusText).toBe('Server Error');
+        }
+      );
+
+      const req = httpMock.expectOne(`${apiUrl}/${pedidoId}/confirmar-pago-mercadopago`);
+      expect(req.request.method).toBe('POST');
+      req.flush(errorMessage, mockErrorResponse);
+    });
+  });
+});

--- a/src/app/services/pago.service.ts
+++ b/src/app/services/pago.service.ts
@@ -1,9 +1,17 @@
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class PagoService {
 
-  constructor() { }
+  private apiUrl = 'http://localhost:8080/api/orders';
+
+  constructor(private http: HttpClient) { }
+
+  confirmarPagoMercadoPago(pedidoId: number): Observable<any> {
+    return this.http.post<any>(`${this.apiUrl}/${pedidoId}/confirmar-pago-mercadopago`, {});
+  }
 }


### PR DESCRIPTION
Integrates Mercado Pago into the payment process.

Key changes:
- Modified `PagoComponent` to handle redirection to Mercado Pago and process callback information (via URL query parameters like `collection_status` and `external_reference`).
- Upon successful payment confirmation from Mercado Pago, the component calls a service to update the backend.
- Added `confirmarPagoMercadoPago` method to `PagoService` which makes a POST request to `/api/orders/:pedidoId/confirmar-pago-mercadopago` to notify the backend of a successful payment.
- Enhanced the `PagoComponent` template to display a success message when payment is verified.
- Added comprehensive unit tests for `PagoService` and `PagoComponent` to cover the new Mercado Pago logic, including various callback scenarios and error handling.

This addresses the issue of completing the "Pago" page with the Mercado Pago option, using an "orders" endpoint to finalize the payment status update from the frontend to the backend.