### PR TITLE
feat: Implement user order listing and detail views

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^18.0.1",
-        "@angular/cli": "^18.0.1",
+        "@angular/cli": "^18.2.19",
         "@angular/compiler-cli": "^18.0.0",
         "@types/express": "^4.17.17",
         "@types/jasmine": "~5.1.0",
@@ -275,11 +275,12 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "18.2.18",
+      "version": "18.2.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-18.2.19.tgz",
+      "integrity": "sha512-P/0KjkzOf2ZShuShx3cBbjLI7XlcS6B/yCRBo1MQfCC4cZfmzPQoUEOSQeYZgy5pnC24f+dKh/+TWc5uYL/Lvg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.18",
+        "@angular-devkit/core": "18.2.19",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.11",
         "ora": "5.4.1",
@@ -291,10 +292,38 @@
         "yarn": ">= 1.13.0"
       }
     },
+    "node_modules/@angular-devkit/schematics/node_modules/@angular-devkit/core": {
+      "version": "18.2.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.19.tgz",
+      "integrity": "sha512-Ptf92Zomc6FCr7GWmHKdgOUbA1GpctZwH/hRcpYpU3tM56MG2t5FOFpufnE595GgolOCktabkFEoODMG8PBVDQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.2",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.5.2"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
       "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -450,16 +479,17 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "18.2.18",
+      "version": "18.2.19",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-18.2.19.tgz",
+      "integrity": "sha512-LGVMTc36JQuw8QX8Sclxyei306EQW3KslopXbf7cfqt6D5/fHS+FqqA0O7V8ob/vOGMca+l6hQD27nW5Y3W6pA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.1802.18",
-        "@angular-devkit/core": "18.2.18",
-        "@angular-devkit/schematics": "18.2.18",
+        "@angular-devkit/architect": "0.1802.19",
+        "@angular-devkit/core": "18.2.19",
+        "@angular-devkit/schematics": "18.2.19",
         "@inquirer/prompts": "5.3.8",
         "@listr2/prompt-adapter-inquirer": "2.0.15",
-        "@schematics/angular": "18.2.18",
+        "@schematics/angular": "18.2.19",
         "@yarnpkg/lockfile": "1.1.0",
         "ini": "4.1.3",
         "jsonc-parser": "3.3.1",
@@ -479,6 +509,57 @@
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/@angular-devkit/architect": {
+      "version": "0.1802.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1802.19.tgz",
+      "integrity": "sha512-M4B1tzxGX1nWCZr9GMM8OO0yBJO2HFSdK8M8P74vEFQfKIeq3y16IQ5zlEveJrkCOFVtmlIy2C9foMCdNyBRMA==",
+      "dev": true,
+      "dependencies": {
+        "@angular-devkit/core": "18.2.19",
+        "rxjs": "7.8.1"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@angular/cli/node_modules/@angular-devkit/core": {
+      "version": "18.2.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.19.tgz",
+      "integrity": "sha512-Ptf92Zomc6FCr7GWmHKdgOUbA1GpctZwH/hRcpYpU3tM56MG2t5FOFpufnE595GgolOCktabkFEoODMG8PBVDQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.2",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.5.2"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@angular/cli/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@angular/common": {
@@ -2942,18 +3023,55 @@
       ]
     },
     "node_modules/@schematics/angular": {
-      "version": "18.2.18",
+      "version": "18.2.19",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-18.2.19.tgz",
+      "integrity": "sha512-s9aynH/fwB/LT94miVfsaL2C4Qd5BLgjMzWFx7iJ8Hyv7FjOBGYO6eGVovjCt2c6/abG+GQAk4EBOCfg3AUtCA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "18.2.18",
-        "@angular-devkit/schematics": "18.2.18",
+        "@angular-devkit/core": "18.2.19",
+        "@angular-devkit/schematics": "18.2.19",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
+      }
+    },
+    "node_modules/@schematics/angular/node_modules/@angular-devkit/core": {
+      "version": "18.2.19",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-18.2.19.tgz",
+      "integrity": "sha512-Ptf92Zomc6FCr7GWmHKdgOUbA1GpctZwH/hRcpYpU3tM56MG2t5FOFpufnE595GgolOCktabkFEoODMG8PBVDQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "8.17.1",
+        "ajv-formats": "3.0.1",
+        "jsonc-parser": "3.3.1",
+        "picomatch": "4.0.2",
+        "rxjs": "7.8.1",
+        "source-map": "0.7.4"
+      },
+      "engines": {
+        "node": "^18.19.1 || ^20.11.1 || >=22.0.0",
+        "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
+        "yarn": ">= 1.13.0"
+      },
+      "peerDependencies": {
+        "chokidar": "^3.5.2"
+      },
+      "peerDependenciesMeta": {
+        "chokidar": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@schematics/angular/node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
       }
     },
     "node_modules/@sigstore/bundle": {
@@ -4667,8 +4785,27 @@
       }
     },
     "node_modules/cuentos-killa-fe": {
-      "resolved": "",
-      "link": true
+      "version": "0.0.0",
+      "resolved": "file:",
+      "dependencies": {
+        "@angular/animations": "^18.0.0",
+        "@angular/cdk": "^18.2.14",
+        "@angular/common": "^18.0.0",
+        "@angular/compiler": "^18.0.0",
+        "@angular/core": "^18.0.0",
+        "@angular/forms": "^18.0.0",
+        "@angular/material": "^18.2.14",
+        "@angular/platform-browser": "^18.0.0",
+        "@angular/platform-browser-dynamic": "^18.0.0",
+        "@angular/platform-server": "^18.0.0",
+        "@angular/router": "^18.0.0",
+        "@angular/ssr": "^18.0.1",
+        "cuentos-killa-fe": "file:",
+        "express": "^4.18.2",
+        "rxjs": "~7.8.0",
+        "tslib": "^2.3.0",
+        "zone.js": "~0.14.3"
+      }
     },
     "node_modules/custom-event": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^18.0.1",
-    "@angular/cli": "^18.0.1",
+    "@angular/cli": "^18.2.19",
     "@angular/compiler-cli": "^18.0.0",
     "@types/express": "^4.17.17",
     "@types/jasmine": "~5.1.0",

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -9,6 +9,8 @@ import { AdminCuentosComponent } from './components/pages/admin/admin-cuentos/ad
 import { AdminLayoutComponent } from './components/pages/admin/admin-layout/admin-layout.component';
 import { PagoComponent } from './components/pages/pago/pago.component';
 import { VoucherComponent } from './components/pages/voucher/voucher.component';
+import { OrderListComponent } from './pages/order-list/order-list.component';
+import { OrderDetailComponent } from './pages/order-detail/order-detail.component';
 
 
 export const routes: Routes = [
@@ -33,6 +35,8 @@ export const routes: Routes = [
       { path: 'pago/:id', component: PagoComponent },
       { path: 'voucher/:id', component: VoucherComponent }, // si vas a subir comprobante
       { path: 'login', component: LoginComponent },
+      { path: 'pedidos', component: OrderListComponent, canActivate: [authGuard] },
+      { path: 'pedidos/:id', component: OrderDetailComponent, canActivate: [authGuard] },
       {
         path: 'admin',
         loadChildren: () => import('./components/pages/admin/admin.module').then(m => m.AdminModule)

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -13,6 +13,9 @@
         <span class="cart-label">Carrito</span>
       </div>
     </li>
+    <li *ngIf="user">
+      <a routerLink="/pedidos" routerLinkActive="active">Mis Pedidos</a>
+    </li>
     <li *ngIf="!user">
       <button class="btn-login" (click)="openLoginDialog()">Login</button>
     </li>

--- a/src/app/model/pedido.model.ts
+++ b/src/app/model/pedido.model.ts
@@ -1,17 +1,21 @@
 export interface PedidoItem {
-    cuentoId: number;
-    cantidad: number;
-  }
-  
-  export interface Pedido {
-    nombre: string;
-    correo: string;
-    direccion: string;
-    telefono: string;
-    items: PedidoItem[];
-    total: number;
-    estado: string; // ejemplo: 'PAGO PENDIENTE'
-    userId: number;
-    correoUsuario:string;
-  }
-  
+  nombreCuento: string;
+  imagenUrl: string;
+  precioUnitario: number;
+  cantidad: number;
+  subtotal: number;
+}
+
+export interface Pedido {
+  id: number;
+  fecha: string; // O Date, dependiendo de la API
+  nombre: string;
+  correo: string;
+  direccion: string;
+  telefono: string;
+  items: PedidoItem[];
+  total: number;
+  estado: string; // ejemplo: 'PAGO PENDIENTE', 'PAGADO', 'ENVIADO', 'ENTREGADO'
+  userId: number;
+  correoUsuario: string;
+}

--- a/src/app/pages/order-detail/order-detail.component.html
+++ b/src/app/pages/order-detail/order-detail.component.html
@@ -1,0 +1,63 @@
+<div class="order-detail-container">
+  <button (click)="volverAPedidos()" class="btn btn-link btn-volver">
+    <i class="fas fa-arrow-left"></i> Volver a mis pedidos
+  </button>
+
+  <div *ngIf="isLoading" class="loading-indicator">
+    <p>Cargando detalle del pedido...</p>
+  </div>
+
+  <div *ngIf="errorMensaje && !isLoading" class="error-mensaje">
+    <p>{{ errorMensaje }}</p>
+  </div>
+
+  <div *ngIf="!isLoading && !pedido && !errorMensaje" class="no-data-mensaje">
+    <p>No se encontró el pedido solicitado.</p>
+  </div>
+
+  <div *ngIf="pedido && !isLoading" class="pedido-content">
+    <h2>Detalle del Pedido #{{ pedido.id }}</h2>
+
+    <section class="pedido-info-general">
+      <h3>Información General</h3>
+      <div class="info-grid">
+        <p><strong>ID del Pedido:</strong> {{ pedido.id }}</p>
+        <p><strong>Fecha:</strong> {{ pedido.fecha | date:'dd/MM/yyyy HH:mm' }}</p>
+        <p><strong>Estado:</strong> <span class="status" [ngClass]="'status-' + pedido.estado.toLowerCase().replace(' ', '-')">{{ pedido.estado }}</span></p>
+        <p><strong>Nombre:</strong> {{ pedido.nombre }}</p>
+        <p><strong>Correo:</strong> {{ pedido.correo }}</p>
+        <p><strong>Dirección:</strong> {{ pedido.direccion }}</p>
+        <p><strong>Teléfono:</strong> {{ pedido.telefono }}</p>
+        <p><strong>Total del Pedido:</strong> <span class="total-amount">{{ pedido.total | currency:'USD':'symbol':'1.2-2' }}</span></p>
+      </div>
+    </section>
+
+    <section class="pedido-items">
+      <h3>Items del Pedido</h3>
+      <div *ngIf="pedido.items && pedido.items.length > 0; else noItems">
+        <div *ngFor="let item of pedido.items" class="item-card">
+          <div class="item-imagen">
+            <img [src]="item.imagenUrl || 'assets/images/placeholder-cuento.png'" [alt]="item.nombreCuento" class="img-fluid">
+          </div>
+          <div class="item-detalles">
+            <h4>{{ item.nombreCuento }}</h4>
+            <p><strong>Precio Unitario:</strong> {{ item.precioUnitario | currency:'USD':'symbol':'1.2-2' }}</p>
+            <p><strong>Cantidad:</strong> {{ item.cantidad }}</p>
+            <p><strong>Subtotal:</strong> {{ item.subtotal | currency:'USD':'symbol':'1.2-2' }}</p>
+          </div>
+        </div>
+      </div>
+      <ng-template #noItems>
+        <p>No hay items en este pedido.</p>
+      </ng-template>
+    </section>
+
+    <section class="acciones-pedido" *ngIf="!isLoading">
+      <button *ngIf="isPagoPendiente()" (click)="pagarAhora()" class="btn btn-success btn-pagar">
+        <i class="fas fa-credit-card"></i> Pagar ahora
+      </button>
+      <!-- Otros botones de acción podrían ir aquí, ej. "Cancelar Pedido" si el estado lo permite -->
+    </section>
+
+  </div>
+</div>

--- a/src/app/pages/order-detail/order-detail.component.scss
+++ b/src/app/pages/order-detail/order-detail.component.scss
@@ -1,0 +1,223 @@
+@import '../../../styles.scss'; // Ajusta la ruta si es necesario
+
+.order-detail-container {
+  padding: 2rem;
+  max-width: 900px;
+  margin: 2rem auto;
+  background-color: var(--background-light);
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-lg);
+
+  .btn-volver {
+    display: inline-flex;
+    align-items: center;
+    color: var(--primary-color);
+    text-decoration: none;
+    font-size: 1rem;
+    margin-bottom: 1.5rem;
+    background-color: transparent;
+    border: none;
+    padding: 0.5rem 0;
+
+    i {
+      margin-right: 0.5rem;
+    }
+
+    &:hover {
+      color: var(--primary-dark);
+      text-decoration: underline;
+    }
+  }
+
+  .loading-indicator,
+  .error-mensaje,
+  .no-data-mensaje {
+    text-align: center;
+    padding: 2rem;
+    border-radius: var(--border-radius-md);
+    margin: 2rem 0;
+    font-size: 1.2rem;
+    color: var(--text-color);
+  }
+
+  .error-mensaje {
+    background-color: var(--danger-light);
+    color: var(--danger-dark);
+    border: 1px solid var(--danger-color);
+  }
+
+  .no-data-mensaje {
+    background-color: var(--warning-light);
+    color: var(--warning-dark);
+    border: 1px solid var(--warning-color);
+  }
+
+  .pedido-content {
+    h2 {
+      color: var(--primary-color);
+      text-align: center;
+      margin-bottom: 2rem;
+      font-size: 2.2rem;
+      border-bottom: 2px solid var(--accent-color);
+      padding-bottom: 0.5rem;
+    }
+
+    section {
+      margin-bottom: 2rem;
+      padding: 1.5rem;
+      background-color: #fff; // Lighter background for sections
+      border-radius: var(--border-radius-md);
+      box-shadow: var(--shadow-sm);
+
+      h3 {
+        color: var(--secondary-color);
+        font-size: 1.6rem;
+        margin-bottom: 1rem;
+        padding-bottom: 0.5rem;
+        border-bottom: 1px solid var(--grey-light);
+      }
+    }
+
+    .pedido-info-general {
+      .info-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+        gap: 1rem;
+
+        p {
+          font-size: 1rem;
+          color: var(--text-color-light);
+          margin-bottom: 0.5rem;
+          background-color: var(--background-very-light);
+          padding: 0.75rem;
+          border-radius: var(--border-radius-sm);
+
+          strong {
+            color: var(--text-color);
+          }
+        }
+        .total-amount {
+          font-weight: bold;
+          font-size: 1.2rem;
+          color: var(--success-color);
+        }
+        .status {
+          font-weight: bold;
+          padding: 0.25rem 0.5rem;
+          border-radius: var(--border-radius-sm);
+          color: #fff;
+          text-transform: uppercase;
+          font-size: 0.9rem;
+          display: inline-block; // Para que el padding y background se apliquen bien
+
+          // Colores de estado (ejemplos, ajusta según tus estados reales)
+          &.status-pago-pendiente, &.status-pendiente { background-color: var(--warning-color); }
+          &.status-pagado { background-color: var(--success-color); }
+          &.status-enviado { background-color: var(--info-color); }
+          &.status-entregado { background-color: var(--primary-color); }
+          &.status-cancelado { background-color: var(--danger-color); }
+        }
+      }
+    }
+
+    .pedido-items {
+      .item-card {
+        display: flex;
+        align-items: flex-start;
+        gap: 1.5rem;
+        padding: 1rem;
+        margin-bottom: 1rem;
+        border: 1px solid var(--grey-light);
+        border-radius: var(--border-radius-md);
+        background-color: var(--background-very-light);
+
+        .item-imagen {
+          flex-shrink: 0;
+          width: 100px; // Ajusta según necesidad
+          height: 100px; // Ajusta según necesidad
+          img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            border-radius: var(--border-radius-sm);
+          }
+        }
+
+        .item-detalles {
+          flex-grow: 1;
+          h4 {
+            color: var(--primary-color);
+            font-size: 1.2rem;
+            margin-bottom: 0.5rem;
+          }
+          p {
+            margin-bottom: 0.25rem;
+            font-size: 0.95rem;
+            color: var(--text-color-light);
+            strong {
+              color: var(--text-color);
+            }
+          }
+        }
+      }
+      .noItems p {
+        font-style: italic;
+        color: var(--text-color-light);
+      }
+    }
+
+    .acciones-pedido {
+      text-align: center;
+      margin-top: 2rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid var(--grey-light);
+
+      .btn-pagar {
+        background-color: var(--success-color);
+        border-color: var(--success-color);
+        color: #fff;
+        font-size: 1.2rem;
+        padding: 0.75rem 1.5rem;
+
+        i {
+          margin-right: 0.75rem;
+        }
+
+        &:hover {
+          background-color: var(--success-dark);
+          border-color: var(--success-dark);
+        }
+      }
+    }
+  }
+}
+
+// Media queries
+@media (max-width: 768px) {
+  .order-detail-container {
+    padding: 1rem;
+    margin: 1rem;
+
+    .pedido-content {
+      h2 {
+        font-size: 1.8rem;
+      }
+      section h3 {
+        font-size: 1.4rem;
+      }
+      .pedido-info-general .info-grid {
+        grid-template-columns: 1fr; // Una columna en pantallas pequeñas
+      }
+      .item-card {
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+        .item-imagen {
+          margin-bottom: 1rem;
+          width: 120px;
+          height: 120px;
+        }
+      }
+    }
+  }
+}

--- a/src/app/pages/order-detail/order-detail.component.spec.ts
+++ b/src/app/pages/order-detail/order-detail.component.spec.ts
@@ -1,0 +1,206 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { By } from '@angular/platform-browser';
+import { of, throwError } from 'rxjs';
+import { OrderDetailComponent } from './order-detail.component';
+import { PedidoService } from '../../services/pedido.service';
+import { Pedido, PedidoItem } from '../../model/pedido.model';
+import { CommonModule } from '@angular/common'; // For pipes
+
+describe('OrderDetailComponent', () => {
+  let component: OrderDetailComponent;
+  let fixture: ComponentFixture<OrderDetailComponent>;
+  let mockPedidoService: jasmine.SpyObj<PedidoService>;
+  let mockRouter: jasmine.SpyObj<Router>;
+  let mockActivatedRoute: any; // Using 'any' for simplicity in setting snapshot
+
+  const mockPedidoId = 1;
+  const mockPedidoData: Pedido = {
+    id: mockPedidoId,
+    fecha: '2023-01-15T10:00:00Z',
+    nombre: 'Cliente A',
+    correo: 'a@a.com',
+    direccion: 'Dir A',
+    telefono: '123',
+    items: [
+      { nombreCuento: 'Cuento 1', imagenUrl: 'img1.jpg', precioUnitario: 10, cantidad: 1, subtotal: 10 },
+      { nombreCuento: 'Cuento 2', imagenUrl: 'img2.jpg', precioUnitario: 15, cantidad: 2, subtotal: 30 }
+    ],
+    total: 40,
+    estado: 'PAGO PENDIENTE',
+    userId: 1,
+    correoUsuario: 'a@a.com'
+  };
+
+  beforeEach(async () => {
+    mockPedidoService = jasmine.createSpyObj('PedidoService', ['getOrderById']);
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+    mockActivatedRoute = {
+      snapshot: {
+        paramMap: convertToParamMap({ id: mockPedidoId.toString() })
+      }
+    };
+
+    await TestBed.configureTestingModule({
+      declarations: [OrderDetailComponent],
+      imports: [
+        RouterTestingModule,
+        CommonModule // For DatePipe, CurrencyPipe
+      ],
+      providers: [
+        { provide: PedidoService, useValue: mockPedidoService },
+        { provide: Router, useValue: mockRouter },
+        { provide: ActivatedRoute, useValue: mockActivatedRoute }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OrderDetailComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('ngOnInit', () => {
+    it('should call pedidoService.getOrderById with correct ID and set isLoading correctly', fakeAsync(() => {
+      mockPedidoService.getOrderById.and.returnValue(of(mockPedidoData));
+      expect(component.isLoading).toBe(true);
+      component.ngOnInit();
+      tick();
+      expect(mockPedidoService.getOrderById).toHaveBeenCalledWith(mockPedidoId);
+      expect(component.isLoading).toBe(false);
+    }));
+
+    it('should assign pedido data on successful fetch', fakeAsync(() => {
+      mockPedidoService.getOrderById.and.returnValue(of(mockPedidoData));
+      component.ngOnInit();
+      tick();
+      expect(component.pedido).toEqual(mockPedidoData);
+      expect(component.errorMensaje).toBeNull();
+    }));
+
+    it('should set errorMensaje and isLoading to false if service call fails', fakeAsync(() => {
+      const errorResponse = { status: 404, message: 'Not Found' };
+      mockPedidoService.getOrderById.and.returnValue(throwError(() => errorResponse));
+      component.ngOnInit();
+      tick();
+      expect(component.isLoading).toBe(false);
+      expect(component.errorMensaje).toBe('No se pudo cargar el detalle del pedido. Verifique el ID o intente más tarde.');
+      expect(component.pedido).toBeUndefined();
+    }));
+
+    it('should set errorMensaje if idParam is not found in route', fakeAsync(() => {
+      mockActivatedRoute.snapshot.paramMap = convertToParamMap({}); // No ID
+      component.ngOnInit();
+      tick();
+      expect(component.isLoading).toBe(false);
+      expect(component.errorMensaje).toBe('ID de pedido no encontrado en la URL.');
+      expect(mockPedidoService.getOrderById).not.toHaveBeenCalled();
+    }));
+  });
+
+  describe('volverAPedidos', () => {
+    it('should navigate to /pedidos', () => {
+      component.volverAPedidos();
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/pedidos']);
+    });
+  });
+
+  describe('pagarAhora', () => {
+    it('should log a message and show an alert', () => {
+      spyOn(console, 'log');
+      spyOn(window, 'alert');
+      component.pedido = mockPedidoData; // Ensure pedido is set
+      component.pagarAhora();
+      expect(console.log).toHaveBeenCalledWith('Intento de pago para el pedido:', mockPedidoData.id);
+      expect(window.alert).toHaveBeenCalledWith('Funcionalidad de pago aún no implementada. Serás redirigido a una página de simulación.');
+    });
+  });
+  
+  describe('isPagoPendiente', () => {
+    it('should return true if estado is PAGO PENDIENTE', () => {
+      component.pedido = { ...mockPedidoData, estado: 'PAGO PENDIENTE' };
+      expect(component.isPagoPendiente()).toBeTrue();
+    });
+    it('should return true if estado is PENDIENTE (case insensitive)', () => {
+      component.pedido = { ...mockPedidoData, estado: 'pendiente' };
+      expect(component.isPagoPendiente()).toBeTrue();
+    });
+    it('should return false if estado is not PAGO PENDIENTE', () => {
+      component.pedido = { ...mockPedidoData, estado: 'ENTREGADO' };
+      expect(component.isPagoPendiente()).toBeFalse();
+    });
+     it('should return false if pedido is undefined', () => {
+      component.pedido = undefined;
+      expect(component.isPagoPendiente()).toBeFalse();
+    });
+  });
+
+  describe('Template Rendering', () => {
+    beforeEach(fakeAsync(() => {
+      mockPedidoService.getOrderById.and.returnValue(of(mockPedidoData));
+      component.ngOnInit();
+      tick();
+      fixture.detectChanges();
+    }));
+
+    it('should display "Detalle del Pedido #ID" title', () => {
+      const titleElement = fixture.debugElement.query(By.css('.pedido-content h2'));
+      expect(titleElement.nativeElement.textContent).toContain(`Detalle del Pedido #${mockPedidoData.id}`);
+    });
+
+    it('should display general order information', () => {
+      const infoGrid = fixture.debugElement.query(By.css('.pedido-info-general .info-grid'));
+      expect(infoGrid.nativeElement.textContent).toContain(`ID del Pedido: ${mockPedidoData.id}`);
+      // Add more checks for other fields like fecha, estado, total, etc. using pipes if needed
+      expect(infoGrid.nativeElement.textContent).toContain(`Estado: ${mockPedidoData.estado}`);
+      expect(infoGrid.nativeElement.textContent).toContain(`Nombre: ${mockPedidoData.nombre}`);
+    });
+
+    it('should display order items', () => {
+      const itemCards = fixture.debugElement.queryAll(By.css('.pedido-items .item-card'));
+      expect(itemCards.length).toBe(mockPedidoData.items.length);
+      
+      const firstItemCard = itemCards[0].nativeElement;
+      const firstItemData = mockPedidoData.items[0];
+      expect(firstItemCard.textContent).toContain(firstItemData.nombreCuento);
+      expect(firstItemCard.textContent).toContain(`Cantidad: ${firstItemData.cantidad}`);
+      // Add checks for precioUnitario, subtotal, imagenUrl
+    });
+
+    it('should display "Pagar ahora" button if order status is PAGO PENDIENTE', () => {
+      component.pedido = { ...mockPedidoData, estado: 'PAGO PENDIENTE' };
+      fixture.detectChanges();
+      const pagarButton = fixture.debugElement.query(By.css('.btn-pagar'));
+      expect(pagarButton).toBeTruthy();
+      expect(pagarButton.nativeElement.textContent).toContain('Pagar ahora');
+    });
+
+    it('should NOT display "Pagar ahora" button if order status is not PAGO PENDIENTE', () => {
+      component.pedido = { ...mockPedidoData, estado: 'ENTREGADO' };
+      fixture.detectChanges();
+      const pagarButton = fixture.debugElement.query(By.css('.btn-pagar'));
+      expect(pagarButton).toBeNull();
+    });
+    
+    it('should call pagarAhora when "Pagar ahora" button is clicked', () => {
+      spyOn(component, 'pagarAhora');
+      component.pedido = { ...mockPedidoData, estado: 'PAGO PENDIENTE' };
+      fixture.detectChanges();
+      const pagarButton = fixture.debugElement.query(By.css('.btn-pagar'));
+      pagarButton.triggerEventHandler('click', null);
+      expect(component.pagarAhora).toHaveBeenCalled();
+    });
+
+    it('should display "Volver a mis pedidos" button and it should call volverAPedidos', () => {
+      spyOn(component, 'volverAPedidos');
+      const backButton = fixture.debugElement.query(By.css('.btn-volver'));
+      expect(backButton).toBeTruthy();
+      expect(backButton.nativeElement.textContent).toContain('Volver a mis pedidos');
+      backButton.triggerEventHandler('click', null);
+      expect(component.volverAPedidos).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/pages/order-detail/order-detail.component.ts
+++ b/src/app/pages/order-detail/order-detail.component.ts
@@ -1,0 +1,63 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { Pedido, PedidoItem } from '../../model/pedido.model';
+import { PedidoService } from '../../services/pedido.service';
+
+@Component({
+  selector: 'app-order-detail',
+  templateUrl: './order-detail.component.html',
+  styleUrls: ['./order-detail.component.scss']
+})
+export class OrderDetailComponent implements OnInit {
+  pedido?: Pedido;
+  isLoading: boolean = true;
+  errorMensaje: string | null = null;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private pedidoService: PedidoService
+  ) {}
+
+  ngOnInit(): void {
+    const idParam = this.route.snapshot.paramMap.get('id');
+    if (idParam) {
+      const pedidoId = +idParam; // Convert string to number
+      this.pedidoService.getOrderById(pedidoId).subscribe({
+        next: (data) => {
+          this.pedido = data;
+          this.isLoading = false;
+        },
+        error: (err) => {
+          console.error('Error fetching order details:', err);
+          this.errorMensaje = 'No se pudo cargar el detalle del pedido. Verifique el ID o intente más tarde.';
+          this.isLoading = false;
+        }
+      });
+    } else {
+      this.errorMensaje = 'ID de pedido no encontrado en la URL.';
+      this.isLoading = false;
+      // Consider navigating back or showing a more prominent error
+    }
+  }
+
+  volverAPedidos(): void {
+    this.router.navigate(['/pedidos']);
+  }
+
+  pagarAhora(): void {
+    // Lógica de pago real podría ir aquí
+    // Por ahora, solo un log y/o redirección a una página de placeholder
+    console.log('Intento de pago para el pedido:', this.pedido?.id);
+    if (this.pedido) {
+      // Ejemplo: Redirigir a una ruta de pago simulada o real
+      // this.router.navigate(['/pago', this.pedido.id]);
+      alert('Funcionalidad de pago aún no implementada. Serás redirigido a una página de simulación.');
+    }
+  }
+
+  // Helper para verificar si el pedido está pendiente de pago
+  isPagoPendiente(): boolean {
+    return this.pedido?.estado?.toUpperCase() === 'PAGO PENDIENTE' || this.pedido?.estado?.toUpperCase() === 'PENDIENTE';
+  }
+}

--- a/src/app/pages/order-list/order-list.component.html
+++ b/src/app/pages/order-list/order-list.component.html
@@ -1,0 +1,33 @@
+<div class="order-list-container">
+  <h2>Mis Pedidos</h2>
+
+  <div *ngIf="isLoading" class="loading-indicator">
+    <p>Cargando pedidos...</p>
+    <!-- Puedes agregar un spinner aquí si lo deseas -->
+  </div>
+
+  <div *ngIf="errorMensaje && !isLoading" class="error-mensaje">
+    <p>{{ errorMensaje }}</p>
+  </div>
+
+  <div *ngIf="!isLoading && !errorMensaje && pedidos.length === 0" class="no-orders-mensaje">
+    <p>Aún no tienes pedidos.</p>
+    <button routerLink="/cuentos" class="btn btn-primary">Explorar Cuentos</button>
+  </div>
+
+  <div *ngIf="!isLoading && !errorMensaje && pedidos.length > 0" class="orders-grid">
+    <div *ngFor="let pedido of pedidos" class="order-card" (click)="verDetalle(pedido.id)" role="button" tabindex="0" (keydown.enter)="verDetalle(pedido.id)">
+      <div class="card-header">
+        <h3>Pedido #{{ pedido.id }}</h3>
+      </div>
+      <div class="card-content">
+        <p><strong>Fecha:</strong> {{ pedido.fecha | date:'dd/MM/yyyy' }}</p>
+        <p><strong>Estado:</strong> <span class="status" [ngClass]="'status-' + pedido.estado.toLowerCase().replace(' ', '-')">{{ pedido.estado }}</span></p>
+        <p><strong>Total:</strong> {{ pedido.total | currency:'USD':'symbol':'1.2-2' }}</p>
+      </div>
+      <div class="card-footer">
+        <button class="btn btn-secondary">Ver Detalle</button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/order-list/order-list.component.scss
+++ b/src/app/pages/order-list/order-list.component.scss
@@ -1,0 +1,145 @@
+@import '../../../styles.scss'; // Ajusta la ruta si es necesario
+
+.order-list-container {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+
+  h2 {
+    color: var(--primary-color);
+    text-align: center;
+    margin-bottom: 2rem;
+    font-size: 2.5rem;
+  }
+
+  .loading-indicator,
+  .error-mensaje,
+  .no-orders-mensaje {
+    text-align: center;
+    padding: 2rem;
+    background-color: var(--background-light);
+    border-radius: var(--border-radius-md);
+    margin-bottom: 1.5rem;
+    font-size: 1.2rem;
+    color: var(--text-color);
+  }
+
+  .error-mensaje {
+    background-color: var(--danger-light);
+    color: var(--danger-dark);
+    border: 1px solid var(--danger-color);
+  }
+
+  .no-orders-mensaje {
+    .btn-primary {
+      margin-top: 1rem;
+      background-color: var(--secondary-color);
+      border-color: var(--secondary-color);
+      color: #fff;
+
+      &:hover {
+        background-color: var(--secondary-dark);
+        border-color: var(--secondary-dark);
+      }
+    }
+  }
+
+  .orders-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 1.5rem;
+  }
+
+  .order-card {
+    background-color: var(--background-light);
+    border-radius: var(--border-radius-lg);
+    box-shadow: var(--shadow-sm);
+    padding: 1.5rem;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    cursor: pointer;
+
+    &:hover {
+      transform: translateY(-5px);
+      box-shadow: var(--shadow-md);
+    }
+
+    .card-header {
+      h3 {
+        color: var(--primary-color);
+        font-size: 1.5rem;
+        margin-bottom: 1rem;
+        border-bottom: 1px solid var(--grey-light);
+        padding-bottom: 0.5rem;
+      }
+    }
+
+    .card-content {
+      p {
+        margin-bottom: 0.75rem;
+        font-size: 1rem;
+        color: var(--text-color-light);
+
+        strong {
+          color: var(--text-color);
+        }
+      }
+
+      .status {
+        font-weight: bold;
+        padding: 0.25rem 0.5rem;
+        border-radius: var(--border-radius-sm);
+        color: #fff;
+        text-transform: uppercase;
+        font-size: 0.8rem;
+
+        // Colores de estado (ejemplos, ajusta según tus estados reales)
+        &.status-pago-pendiente { background-color: var(--warning-color); }
+        &.status-pagado { background-color: var(--success-color); }
+        &.status-enviado { background-color: var(--info-color); }
+        &.status-entregado { background-color: var(--primary-color); }
+        &.status-cancelado { background-color: var(--danger-color); }
+        // ...otros estados
+      }
+    }
+
+    .card-footer {
+      margin-top: 1rem;
+      text-align: right;
+
+      .btn-secondary {
+        background-color: var(--accent-color);
+        border-color: var(--accent-color);
+        color: #fff;
+
+        &:hover {
+          background-color: var(--accent-dark);
+          border-color: var(--accent-dark);
+        }
+      }
+    }
+  }
+}
+
+// Media queries para responsiveness
+@media (max-width: 768px) {
+  .order-list-container {
+    padding: 1rem;
+    h2 {
+      font-size: 2rem;
+    }
+  }
+
+  .orders-grid {
+    grid-template-columns: 1fr; // Una columna en pantallas pequeñas
+  }
+
+  .order-card {
+    padding: 1rem;
+    .card-header h3 {
+      font-size: 1.3rem;
+    }
+    .card-content p {
+      font-size: 0.9rem;
+    }
+  }
+}

--- a/src/app/pages/order-list/order-list.component.spec.ts
+++ b/src/app/pages/order-list/order-list.component.spec.ts
@@ -1,0 +1,160 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { By } from '@angular/platform-browser';
+import { of, throwError } from 'rxjs';
+import { OrderListComponent } from './order-list.component';
+import { PedidoService } from '../../services/pedido.service';
+import { Pedido } from '../../model/pedido.model';
+import { Router } from '@angular/router';
+import { DatePipe, CurrencyPipe, CommonModule } from '@angular/common'; // Import CommonModule
+
+describe('OrderListComponent', () => {
+  let component: OrderListComponent;
+  let fixture: ComponentFixture<OrderListComponent>;
+  let mockPedidoService: jasmine.SpyObj<PedidoService>;
+  let mockRouter: jasmine.SpyObj<Router>;
+
+  const mockPedidosData: Pedido[] = [
+    { id: 1, fecha: '2023-01-15T10:00:00Z', nombre: 'Cliente A', correo: 'a@a.com', direccion: 'Dir A', telefono: '123', items: [], total: 100, estado: 'ENTREGADO', userId: 1, correoUsuario: 'a@a.com' },
+    { id: 2, fecha: '2023-01-16T11:00:00Z', nombre: 'Cliente B', correo: 'b@b.com', direccion: 'Dir B', telefono: '456', items: [], total: 200, estado: 'PAGO PENDIENTE', userId: 2, correoUsuario: 'b@b.com' }
+  ];
+
+  beforeEach(async () => {
+    mockPedidoService = jasmine.createSpyObj('PedidoService', ['getOrders']);
+    mockRouter = jasmine.createSpyObj('Router', ['navigate']);
+
+    await TestBed.configureTestingModule({
+      declarations: [OrderListComponent], // Declare the component
+      imports: [
+        RouterTestingModule, // Provides basic router stubs
+        CommonModule // Import CommonModule for pipes like DatePipe, CurrencyPipe
+      ],
+      providers: [
+        { provide: PedidoService, useValue: mockPedidoService },
+        { provide: Router, useValue: mockRouter },
+        // DatePipe and CurrencyPipe are usually provided by CommonModule,
+        // but sometimes need to be explicitly provided in tests if not working.
+        // For now, relying on CommonModule.
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OrderListComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('ngOnInit', () => {
+    it('should call pedidoService.getOrders and set isLoading to true initially, then false', fakeAsync(() => {
+      mockPedidoService.getOrders.and.returnValue(of(mockPedidosData));
+      
+      expect(component.isLoading).toBe(true); // Check initial state before ngOnInit
+      component.ngOnInit(); // Trigger ngOnInit
+      tick(); // Simulate passage of time for async operations like observables
+      
+      expect(mockPedidoService.getOrders).toHaveBeenCalled();
+      expect(component.isLoading).toBe(false);
+    }));
+
+    it('should assign pedidos on successful data fetch', fakeAsync(() => {
+      mockPedidoService.getOrders.and.returnValue(of(mockPedidosData));
+      component.ngOnInit();
+      tick();
+      expect(component.pedidos.length).toBe(2);
+      expect(component.pedidos).toEqual(mockPedidosData);
+      expect(component.errorMensaje).toBeNull();
+    }));
+
+    it('should set errorMensaje and isLoading to false if service call fails', fakeAsync(() => {
+      const errorResponse = { status: 500, message: 'Server Error' };
+      mockPedidoService.getOrders.and.returnValue(throwError(() => errorResponse));
+      component.ngOnInit();
+      tick();
+      expect(component.isLoading).toBe(false);
+      expect(component.errorMensaje).toBe('No se pudieron cargar los pedidos. Intente más tarde.');
+      expect(component.pedidos.length).toBe(0);
+    }));
+  });
+
+  describe('verDetalle', () => {
+    it('should navigate to the order detail page with the correct pedidoId', () => {
+      const pedidoId = 123;
+      component.verDetalle(pedidoId);
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/pedidos', pedidoId]);
+    });
+  });
+
+  describe('Template Rendering', () => {
+    it('should display "Mis Pedidos" title', () => {
+      fixture.detectChanges(); // Trigger change detection
+      const titleElement = fixture.debugElement.query(By.css('h2'));
+      expect(titleElement.nativeElement.textContent).toContain('Mis Pedidos');
+    });
+
+    it('should display "Cargando pedidos..." when isLoading is true', () => {
+      component.isLoading = true;
+      fixture.detectChanges();
+      const loadingElement = fixture.debugElement.query(By.css('.loading-indicator p'));
+      expect(loadingElement.nativeElement.textContent).toContain('Cargando pedidos...');
+    });
+
+    it('should display error message when errorMensaje is set', () => {
+      component.isLoading = false;
+      component.errorMensaje = 'Test Error Message';
+      fixture.detectChanges();
+      const errorElement = fixture.debugElement.query(By.css('.error-mensaje p'));
+      expect(errorElement.nativeElement.textContent).toContain('Test Error Message');
+    });
+    
+    it('should display "Aún no tienes pedidos." when pedidos is empty and not loading and no error', () => {
+      component.isLoading = false;
+      component.pedidos = [];
+      component.errorMensaje = null;
+      fixture.detectChanges();
+      const noOrdersElement = fixture.debugElement.query(By.css('.no-orders-mensaje p'));
+      expect(noOrdersElement.nativeElement.textContent).toContain('Aún no tienes pedidos.');
+      const exploreButton = fixture.debugElement.query(By.css('.no-orders-mensaje button'));
+      expect(exploreButton).toBeTruthy();
+      expect(exploreButton.nativeElement.textContent).toContain('Explorar Cuentos');
+    });
+
+    it('should render order cards when pedidos has data', fakeAsync(() => {
+      mockPedidoService.getOrders.and.returnValue(of(mockPedidosData));
+      component.ngOnInit();
+      tick();
+      fixture.detectChanges(); // Update view with fetched data
+
+      const orderCards = fixture.debugElement.queryAll(By.css('.order-card'));
+      expect(orderCards.length).toBe(2);
+
+      const firstCard = orderCards[0];
+      expect(firstCard.query(By.css('.card-header h3')).nativeElement.textContent).toContain(`Pedido #${mockPedidosData[0].id}`);
+      
+      // Use DatePipe for formatting date as in component
+      const datePipe = new DatePipe('en-US');
+      const expectedDate = datePipe.transform(mockPedidosData[0].fecha, 'dd/MM/yyyy');
+      expect(firstCard.nativeElement.textContent).toContain(`Fecha: ${expectedDate}`);
+      
+      expect(firstCard.nativeElement.textContent).toContain(`Estado: ${mockPedidosData[0].estado}`);
+      
+      // Use CurrencyPipe for formatting total as in component
+      const currencyPipe = new CurrencyPipe('en-US', 'USD'); // Adjust locale and currency code as needed
+      const expectedTotal = currencyPipe.transform(mockPedidosData[0].total, 'USD', 'symbol', '1.2-2');
+      expect(firstCard.nativeElement.textContent).toContain(`Total: ${expectedTotal}`);
+    }));
+
+    it('should call verDetalle when an order card is clicked', fakeAsync(() => {
+      spyOn(component, 'verDetalle');
+      mockPedidoService.getOrders.and.returnValue(of(mockPedidosData));
+      component.ngOnInit();
+      tick();
+      fixture.detectChanges();
+
+      const firstCard = fixture.debugElement.query(By.css('.order-card'));
+      firstCard.triggerEventHandler('click', null);
+      expect(component.verDetalle).toHaveBeenCalledWith(mockPedidosData[0].id);
+    }));
+  });
+});

--- a/src/app/pages/order-list/order-list.component.ts
+++ b/src/app/pages/order-list/order-list.component.ts
@@ -1,0 +1,35 @@
+import { Component, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { Pedido } from '../../model/pedido.model';
+import { PedidoService } from '../../services/pedido.service';
+
+@Component({
+  selector: 'app-order-list',
+  templateUrl: './order-list.component.html',
+  styleUrls: ['./order-list.component.scss']
+})
+export class OrderListComponent implements OnInit {
+  pedidos: Pedido[] = [];
+  isLoading: boolean = true;
+  errorMensaje: string | null = null;
+
+  constructor(private pedidoService: PedidoService, private router: Router) {}
+
+  ngOnInit(): void {
+    this.pedidoService.getOrders().subscribe({
+      next: (data) => {
+        this.pedidos = data;
+        this.isLoading = false;
+      },
+      error: (error) => {
+        console.error('Error fetching orders:', error);
+        this.errorMensaje = 'No se pudieron cargar los pedidos. Intente más tarde.';
+        this.isLoading = false;
+      }
+    });
+  }
+
+  verDetalle(pedidoId: number): void {
+    this.router.navigate(['/pedidos', pedidoId]);
+  }
+}

--- a/src/app/services/pedido.service.spec.ts
+++ b/src/app/services/pedido.service.spec.ts
@@ -1,0 +1,104 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { PedidoService } from './pedido.service';
+import { Pedido } from '../model/pedido.model'; // Asegúrate que la ruta es correcta
+
+describe('PedidoService', () => {
+  let service: PedidoService;
+  let httpMock: HttpTestingController;
+  const apiUrl = 'http://localhost:8080/api/orders'; // Base API URL from service
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [PedidoService]
+    });
+    service = TestBed.inject(PedidoService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify(); // Verify that no unmatched requests are outstanding
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getOrders', () => {
+    it('should return a list of orders on successful GET request', () => {
+      const mockPedidos: Pedido[] = [
+        { id: 1, fecha: '2023-01-15', nombre: 'Cliente A', correo: 'a@example.com', direccion: 'Dir A', telefono: '123', items: [], total: 100, estado: 'ENTREGADO', userId: 1, correoUsuario: 'a@example.com' },
+        { id: 2, fecha: '2023-01-16', nombre: 'Cliente B', correo: 'b@example.com', direccion: 'Dir B', telefono: '456', items: [], total: 200, estado: 'PENDIENTE', userId: 2, correoUsuario: 'b@example.com' }
+      ];
+
+      service.getOrders().subscribe(pedidos => {
+        expect(pedidos.length).toBe(2);
+        expect(pedidos).toEqual(mockPedidos);
+      });
+
+      const req = httpMock.expectOne(apiUrl);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockPedidos);
+    });
+
+    it('should handle errors when fetching orders', () => {
+      const errorMessage = 'Error fetching orders';
+      service.getOrders().subscribe({
+        next: () => fail('should have failed with an error'),
+        error: (error) => {
+          expect(error.status).toBe(500);
+          expect(error.statusText).toBe('Server Error');
+        }
+      });
+
+      const req = httpMock.expectOne(apiUrl);
+      expect(req.request.method).toBe('GET');
+      req.flush({ message: errorMessage }, { status: 500, statusText: 'Server Error' });
+    });
+  });
+
+  describe('getOrderById', () => {
+    it('should return a single order on successful GET request', () => {
+      const mockPedido: Pedido = { id: 1, fecha: '2023-01-15', nombre: 'Cliente A', correo: 'a@example.com', direccion: 'Dir A', telefono: '123', items: [], total: 100, estado: 'ENTREGADO', userId: 1, correoUsuario: 'a@example.com' };
+      const pedidoId = 1;
+
+      service.getOrderById(pedidoId).subscribe(pedido => {
+        expect(pedido).toEqual(mockPedido);
+      });
+
+      const req = httpMock.expectOne(`${apiUrl}/${pedidoId}`);
+      expect(req.request.method).toBe('GET');
+      req.flush(mockPedido);
+    });
+
+    it('should handle errors when fetching a single order', () => {
+      const pedidoId = 1;
+      const errorMessage = 'Error fetching order';
+      service.getOrderById(pedidoId).subscribe({
+        next: () => fail('should have failed with an error'),
+        error: (error) => {
+          expect(error.status).toBe(404);
+          expect(error.statusText).toBe('Not Found');
+        }
+      });
+
+      const req = httpMock.expectOne(`${apiUrl}/${pedidoId}`);
+      expect(req.request.method).toBe('GET');
+      req.flush({ message: errorMessage }, { status: 404, statusText: 'Not Found' });
+    });
+
+    it('should handle non-numeric or invalid ID for getOrderById gracefully (compile-time check)', () => {
+      // This is more of a TypeScript compile-time check, but good to keep in mind.
+      // The service method expects a number. If a string were passed, TS would complain.
+      // For runtime, if it somehow gets a non-numeric value that passes TS (e.g. 'any' type),
+      // the HTTP request might fail or be malformed, which our error test above would catch.
+      expect(() => service.getOrderById(NaN)).not.toThrowError(); // Example: it should make a request like /api/orders/NaN
+      const req = httpMock.expectOne(`${apiUrl}/NaN`);
+      req.flush({}, { status: 400, statusText: 'Bad Request' }); // Simulate server responding to bad ID format
+    });
+  });
+
+  // Tests for registrarPedido, uploadVoucher, getOrderStatus can be added here if not already present
+  // For now, focusing on the new methods as per the subtask.
+});

--- a/src/app/services/pedido.service.ts
+++ b/src/app/services/pedido.service.ts
@@ -24,4 +24,12 @@ export class PedidoService {
   getOrderStatus(pedidoId: number): Observable<{ estado: string }> {
     return this.http.get<{ estado: string }>(`${this.apiUrl}/${pedidoId}/status`);
   }
+
+  getOrders(): Observable<Pedido[]> {
+    return this.http.get<Pedido[]>(this.apiUrl);
+  }
+
+  getOrderById(id: number): Observable<Pedido> {
+    return this.http.get<Pedido>(`${this.apiUrl}/${id}`);
+  }
 }


### PR DESCRIPTION
Adds functionality for you to view your past orders and order details.

Key changes include:

- Updated `PedidoService` to include `getOrders()` and `getOrderById()` methods for fetching order data from the API.
- Enhanced `Pedido` and `PedidoItem` model interfaces to align with API responses and view requirements.
- Created `OrderListComponent` to display a list of your orders with summary information (ID, date, status, total) and navigation to details.
- Created `OrderDetailComponent` to display detailed information for a specific order, including items, pricing, and a conditional "Pagar ahora" button for pending payments.
- Added routes `/pedidos` and `/pedidos/:id`, protected by `authGuard`, for the new components.
- Integrated a "Mis Pedidos" link into the main navbar, visible to logged-in users.
- Implemented comprehensive unit tests for the new service methods and components, covering logic, template rendering, and service interactions.