### PR TITLE
Fix: Resolve Angular template and type errors

### DIFF
--- a/src/app/components/pages/checkout/checkout.component.ts
+++ b/src/app/components/pages/checkout/checkout.component.ts
@@ -81,8 +81,11 @@ export class CheckoutComponent implements OnInit {
       direccion: formData.direccion,
       telefono: formData.telefono,
       items: this.itemsCarrito.map(item => ({
-        cuentoId: item.cuento.id,
-        cantidad: item.cantidad
+        nombreCuento: item.cuento.nombre,
+        imagenUrl: item.cuento.imagenUrl,
+        precioUnitario: item.cuento.precio,
+        cantidad: item.cantidad,
+        subtotal: item.cuento.precio * item.cantidad
       })),
       total: this.calcularSubtotal(),
       estado: 'PAGO PENDIENTE',

--- a/src/app/pages/order-detail/order-detail.component.html
+++ b/src/app/pages/order-detail/order-detail.component.html
@@ -16,26 +16,26 @@
   </div>
 
   <div *ngIf="pedido && !isLoading" class="pedido-content">
-    <h2>Detalle del Pedido #{{ pedido.id }}</h2>
+    <h2>Detalle del Pedido #{{ pedido?.id }}</h2>
 
     <section class="pedido-info-general">
       <h3>Información General</h3>
       <div class="info-grid">
-        <p><strong>ID del Pedido:</strong> {{ pedido.id }}</p>
-        <p><strong>Fecha:</strong> {{ pedido.fecha | date:'dd/MM/yyyy HH:mm' }}</p>
-        <p><strong>Estado:</strong> <span class="status" [ngClass]="'status-' + pedido.estado.toLowerCase().replace(' ', '-')">{{ pedido.estado }}</span></p>
-        <p><strong>Nombre:</strong> {{ pedido.nombre }}</p>
-        <p><strong>Correo:</strong> {{ pedido.correo }}</p>
-        <p><strong>Dirección:</strong> {{ pedido.direccion }}</p>
-        <p><strong>Teléfono:</strong> {{ pedido.telefono }}</p>
-        <p><strong>Total del Pedido:</strong> <span class="total-amount">{{ pedido.total | currency:'USD':'symbol':'1.2-2' }}</span></p>
+        <p><strong>ID del Pedido:</strong> {{ pedido?.id }}</p>
+        <p><strong>Fecha:</strong> {{ pedido?.fecha | date:'dd/MM/yyyy HH:mm' }}</p>
+        <p><strong>Estado:</strong> <span class="status" [ngClass]="'status-' + pedido?.estado?.toLowerCase().replace(' ', '-')">{{ pedido?.estado }}</span></p>
+        <p><strong>Nombre:</strong> {{ pedido?.nombre }}</p>
+        <p><strong>Correo:</strong> {{ pedido?.correo }}</p>
+        <p><strong>Dirección:</strong> {{ pedido?.direccion }}</p>
+        <p><strong>Teléfono:</strong> {{ pedido?.telefono }}</p>
+        <p><strong>Total del Pedido:</strong> <span class="total-amount">{{ pedido?.total | currency:'USD':'symbol':'1.2-2' }}</span></p>
       </div>
     </section>
 
     <section class="pedido-items">
       <h3>Items del Pedido</h3>
-      <div *ngIf="pedido.items && pedido.items.length > 0; else noItems">
-        <div *ngFor="let item of pedido.items" class="item-card">
+      <div *ngIf="pedido?.items && pedido?.items.length > 0; else noItems">
+        <div *ngFor="let item of pedido?.items" class="item-card">
           <div class="item-imagen">
             <img [src]="item.imagenUrl || 'assets/images/placeholder-cuento.png'" [alt]="item.nombreCuento" class="img-fluid">
           </div>

--- a/src/app/pages/order-detail/order-detail.component.ts
+++ b/src/app/pages/order-detail/order-detail.component.ts
@@ -2,9 +2,12 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Pedido, PedidoItem } from '../../model/pedido.model';
 import { PedidoService } from '../../services/pedido.service';
+import { CommonModule } from '@angular/common'; // Import CommonModule
 
 @Component({
   selector: 'app-order-detail',
+  standalone: true, // Ensure standalone is true
+  imports: [CommonModule], // Add CommonModule here
   templateUrl: './order-detail.component.html',
   styleUrls: ['./order-detail.component.scss']
 })

--- a/src/app/pages/order-list/order-list.component.ts
+++ b/src/app/pages/order-list/order-list.component.ts
@@ -2,9 +2,12 @@ import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { Pedido } from '../../model/pedido.model';
 import { PedidoService } from '../../services/pedido.service';
+import { CommonModule } from '@angular/common'; // Import CommonModule
 
 @Component({
   selector: 'app-order-list',
+  standalone: true, // Ensure standalone is true
+  imports: [CommonModule], // Add CommonModule here
   templateUrl: './order-list.component.html',
   styleUrls: ['./order-list.component.scss']
 })


### PR DESCRIPTION
This commit addresses several errors in Angular components:

1.  **Type Mismatch (TS2322) in `checkout.component.ts`**: Corrected the mapping of `itemsCarrito` to `PedidoItem[]` in the `registrarPedido` method. Ensured all required fields for `PedidoItem` (`nombreCuento`, `imagenUrl`, `precioUnitario`, `subtotal`) are populated from the `item.cuento` object.

2.  **Unknown Pipes/Directives and Undefined Properties in `order-detail.component`**:
    - Added `CommonModule` to `OrderDetailComponent`'s imports to make `date` pipe, `currency` pipe, and `ngClass` directive available.
    - Implemented safe navigation (`?.`) for `pedido` properties in `order-detail.component.html` to prevent errors from undefined objects during data loading.

3.  **Unknown Pipes/Directives in `order-list.component`**:
    - Added `CommonModule` to `OrderListComponent`'s imports to enable the use of `date` pipe, `currency` pipe, and `ngClass` directive in its template.

These changes should resolve the reported build errors and improve runtime stability.