### PR TITLE
Implement admin dashboard service integration

### DIFF
--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
@@ -1,9 +1,18 @@
 <div class="dashboard-container">
-    <h2>Bienvenido, Admin!</h2>
-    <div class="cards">
-      <div class="card"> <h4>CUENTOS PUBLICADOS</h4><p>{{ cuentosPublicados }}</p> </div>
-      <div class="card"> <h4>PEDIDOS EN PROCESO</h4><p>{{ pedidosEnProceso }}</p> </div>
-      <div class="card"> <h4>USUARIOS REGISTRADOS</h4><p>{{ usuariosRegistrados }}</p> </div>
-      <div class="card"> <h4>VENTAS TOTALES</h4><p>S/ {{ ventasTotales }}</p> </div>
-    </div>
+  <h2>Bienvenido, Admin!</h2>
+
+  <div class="loading-indicator" *ngIf="isLoading">
+    <p>Cargando datos...</p>
   </div>
+
+  <div class="error-mensaje" *ngIf="errorMensaje">
+    <p>{{ errorMensaje }}</p>
+  </div>
+
+  <div class="cards" *ngIf="!isLoading && !errorMensaje">
+    <div class="card"> <h4>CUENTOS PUBLICADOS</h4><p>{{ cuentosPublicados }}</p> </div>
+    <div class="card"> <h4>PEDIDOS EN PROCESO</h4><p>{{ pedidosEnProceso }}</p> </div>
+    <div class="card"> <h4>USUARIOS REGISTRADOS</h4><p>{{ usuariosRegistrados }}</p> </div>
+    <div class="card"> <h4>VENTAS TOTALES</h4><p>S/ {{ ventasTotales }}</p> </div>
+  </div>
+</div>

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.spec.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.spec.ts
@@ -1,23 +1,65 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
 
 import { AdminDashboardComponent } from './admin-dashboard.component';
+import { CuentoService } from '../../../../services/cuento.service';
+import { PedidoService } from '../../../../services/pedido.service';
+import { UserService } from '../../../../services/user.service';
+import { Cuento } from '../../../../model/cuento.model';
+import { Pedido } from '../../../../model/pedido.model';
+import { User } from '../../../../model/user.model';
 
 describe('AdminDashboardComponent', () => {
   let component: AdminDashboardComponent;
   let fixture: ComponentFixture<AdminDashboardComponent>;
+  let cuentoServiceSpy: jasmine.SpyObj<CuentoService>;
+  let pedidoServiceSpy: jasmine.SpyObj<PedidoService>;
+  let userServiceSpy: jasmine.SpyObj<UserService>;
 
   beforeEach(async () => {
+    cuentoServiceSpy = jasmine.createSpyObj('CuentoService', ['obtenerCuentos']);
+    pedidoServiceSpy = jasmine.createSpyObj('PedidoService', ['getOrders']);
+    userServiceSpy = jasmine.createSpyObj('UserService', ['obtenerUsuarios']);
+
     await TestBed.configureTestingModule({
-      imports: [AdminDashboardComponent]
-    })
-    .compileComponents();
+      declarations: [AdminDashboardComponent],
+      providers: [
+        { provide: CuentoService, useValue: cuentoServiceSpy },
+        { provide: PedidoService, useValue: pedidoServiceSpy },
+        { provide: UserService, useValue: userServiceSpy }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AdminDashboardComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should update counters with data from services', () => {
+    cuentoServiceSpy.obtenerCuentos.and.returnValue(of([{} as Cuento, {} as Cuento]));
+    pedidoServiceSpy.getOrders.and.returnValue(of([{} as Pedido]));
+    userServiceSpy.obtenerUsuarios.and.returnValue(of([{} as User, {} as User, {} as User]));
+
+    fixture.detectChanges();
+
+    expect(component.cuentosPublicados).toBe(2);
+    expect(component.pedidosEnProceso).toBe(1);
+    expect(component.usuariosRegistrados).toBe(3);
+    expect(component.isLoading).toBeFalse();
+    expect(component.errorMensaje).toBeNull();
+  });
+
+  it('should handle service errors', () => {
+    cuentoServiceSpy.obtenerCuentos.and.returnValue(throwError(() => new Error('error')));
+    pedidoServiceSpy.getOrders.and.returnValue(of([]));
+    userServiceSpy.obtenerUsuarios.and.returnValue(of([]));
+
+    fixture.detectChanges();
+
+    expect(component.errorMensaje).toBe('No se pudieron cargar las estadísticas');
+    expect(component.isLoading).toBeFalse();
   });
 });

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.ts
@@ -1,4 +1,8 @@
 import { Component, OnInit } from '@angular/core';
+import { forkJoin } from 'rxjs';
+import { CuentoService } from '../../../../services/cuento.service';
+import { PedidoService } from '../../../../services/pedido.service';
+import { UserService } from '../../../../services/user.service';
 
 @Component({
   selector: 'app-admin-dashboard',
@@ -8,11 +12,36 @@ import { Component, OnInit } from '@angular/core';
   styleUrl: './admin-dashboard.component.scss'
 })
 export class AdminDashboardComponent implements OnInit {
-  cuentosPublicados = 10;
-  pedidosEnProceso = 5;
-  usuariosRegistrados = 25;
-  ventasTotales = 1200;
+  cuentosPublicados = 0;
+  pedidosEnProceso = 0;
+  usuariosRegistrados = 0;
+  ventasTotales = 0;
+  isLoading = true;
+  errorMensaje: string | null = null;
 
-  constructor() {}
-  ngOnInit(): void {}
+  constructor(
+    private cuentoService: CuentoService,
+    private pedidoService: PedidoService,
+    private userService: UserService
+  ) {}
+
+  ngOnInit(): void {
+    this.isLoading = true;
+    forkJoin([
+      this.cuentoService.obtenerCuentos(),
+      this.pedidoService.getOrders(),
+      this.userService.obtenerUsuarios()
+    ]).subscribe({
+      next: ([cuentos, pedidos, usuarios]) => {
+        this.cuentosPublicados = cuentos.length;
+        this.pedidosEnProceso = pedidos.length;
+        this.usuariosRegistrados = usuarios.length;
+        this.isLoading = false;
+      },
+      error: () => {
+        this.errorMensaje = 'No se pudieron cargar las estadísticas';
+        this.isLoading = false;
+      }
+    });
+  }
 }

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { User } from '../model/user.model';
+
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  private apiUrl = 'http://localhost:8080/api/users';
+
+  constructor(private http: HttpClient) {}
+
+  obtenerUsuarios(): Observable<User[]> {
+    return this.http.get<User[]>(this.apiUrl);
+  }
+}


### PR DESCRIPTION
## Summary
- add `UserService` for backend user requests
- use CuentoService, PedidoService and UserService in `AdminDashboardComponent`
- show loading/error state in dashboard template
- test that dashboard counters update with service data

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b2bb83148327a2b38ebd9554cb7c