### PR TITLE
Add admin guard and tests

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import { LayoutComponent } from './components/layout/layout.component'; // impor
 import { CheckoutComponent } from './components/pages/checkout/checkout.component';
 import { LoginComponent } from './components/pages/login/login.component';
 import { authGuard } from './guards/auth.guard';
+import { AdminGuard } from './guards/admin.guard';
 import { AdminDashboardComponent } from './components/pages/admin/admin-dashboard/admin-dashboard.component';
 import { AdminPedidosComponent } from './components/pages/admin/admin-pedidos/admin-pedidos.component';
 import { AdminCuentosComponent } from './components/pages/admin/admin-cuentos/admin-cuentos.component';
@@ -39,7 +40,8 @@ export const routes: Routes = [
       { path: 'pedidos/:id', component: OrderDetailComponent, canActivate: [authGuard] },
       {
         path: 'admin',
-        loadChildren: () => import('./components/pages/admin/admin.module').then(m => m.AdminModule)
+        loadChildren: () => import('./components/pages/admin/admin.module').then(m => m.AdminModule),
+        canActivate: [AdminGuard]
       },
       {
         path: '',

--- a/src/app/guards/admin.guard.spec.ts
+++ b/src/app/guards/admin.guard.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { AdminGuard } from './admin.guard';
+import { AuthService } from '../services/auth.service';
+
+describe('AdminGuard', () => {
+  let guard: AdminGuard;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+
+  beforeEach(() => {
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['getUser']);
+    routerSpy = jasmine.createSpyObj('Router', ['navigate'], { url: '/' });
+
+    TestBed.configureTestingModule({
+      providers: [
+        AdminGuard,
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: Router, useValue: routerSpy }
+      ]
+    });
+
+    guard = TestBed.inject(AdminGuard);
+  });
+
+  it('should allow navigation when user is admin', () => {
+    authServiceSpy.getUser.and.returnValue({ role: 'ADMIN' } as any);
+    expect(guard.canActivate()).toBeTrue();
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
+  });
+
+  it('should deny navigation when user is not admin', () => {
+    authServiceSpy.getUser.and.returnValue({ role: 'USER' } as any);
+    expect(guard.canActivate()).toBeFalse();
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/']);
+  });
+});

--- a/src/app/guards/admin.guard.ts
+++ b/src/app/guards/admin.guard.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router } from '@angular/router';
+import { AuthService } from '../services/auth.service';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AdminGuard implements CanActivate {
+
+  constructor(private authService: AuthService, private router: Router) {}
+
+  canActivate(): boolean {
+    const user = this.authService.getUser();
+    if (user && user.role === 'ADMIN') {
+      return true;
+    }
+    this.router.navigate(['/']);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- implement `AdminGuard` for admin role checking
- protect `admin` route using `AdminGuard`
- add unit tests for guard behavior

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b2bff7c88327a13bc1f24ce3c72b