### PR TITLE
Add admin dashboard link

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -13,6 +13,9 @@
         <span class="cart-label">Carrito</span>
       </div>
     </li>
+    <li *ngIf="user?.role === 'ADMIN'">
+      <a routerLink="/admin/dashboard" routerLinkActive="active">Admin</a>
+    </li>
     <li *ngIf="user">
       <a routerLink="/pedidos" routerLinkActive="active">Mis Pedidos</a>
     </li>


### PR DESCRIPTION
## Summary
- show admin dashboard link in navbar when the logged in user is an admin

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b2c419b083279474d273c9a0b62c