### PR TITLE
Add price and added date fields to CuentoCard

### DIFF
--- a/src/app/components/cuento-card/cuento-card.component.html
+++ b/src/app/components/cuento-card/cuento-card.component.html
@@ -2,6 +2,8 @@
   <img [src]="cuento.imagenUrl || 'assets/placeholder-cuento.jpg'" alt="{{cuento.titulo}}" (error)="cargarImagenPlaceholder($event)">
   <h3>{{ cuento.titulo }}</h3>
   <p>{{ cuento.autor }}</p>
+  <p>S/ {{ cuento.precio | number:'1.2-2' }}</p>
+  <p>Agregado: {{ cuento.fechaIngreso | date:'shortDate' }}</p>
 
   <div class="acciones">
     <button (click)="verDetalle()">Ver detalle</button>

--- a/src/app/components/cuento-card/cuento-card.component.scss
+++ b/src/app/components/cuento-card/cuento-card.component.scss
@@ -23,6 +23,12 @@
     margin: 0.5rem 0;
   }
 
+  p {
+    margin: 0.25rem 0;
+    color: #4B3A2F;
+    font-size: 1rem;
+  }
+
   button {
     padding: 0.5rem 1rem;
     border: none;


### PR DESCRIPTION
## Summary
- show price and added date in the cuento card
- add basic styling for new fields

## Testing
- `npm run build` *(fails: `ng` not found)*
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b94120f48327a14d6beb6d50c561