### PR TITLE
Add cuentos page route

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -24,6 +24,10 @@ export const routes: Routes = [
         loadChildren: () =>
           import('./components/pages/Home/home.module').then((m) => m.HomeModule),
       }, {
+        path: 'cuentos',
+        loadChildren: () =>
+          import('./components/pages/Cuentos/cuentos.module').then(m => m.CuentosModule),
+      }, {
         path: 'cuento/:id',
         loadChildren: () =>
           import('./components/detalle-cuento/detalle-cuento.module').then(m => m.DetalleCuentoModule),

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -5,7 +5,7 @@
   </a>
   <ul class="nav-links">
     <li><a routerLink="/home" routerLinkActive="active">Inicio</a></li>
-    <li><a routerLink="/home" routerLinkActive="active">Cuentos</a></li>
+    <li><a routerLink="/cuentos" routerLinkActive="active">Cuentos</a></li>
     <li>
       <a class="carrito-enlace" (click)="abrirCarrito()" style="cursor: pointer;" >
         🛒

--- a/src/app/components/pages/Cuentos/cuentos.component.ts
+++ b/src/app/components/pages/Cuentos/cuentos.component.ts
@@ -2,6 +2,6 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: 'app-cuentos',
-  template: `<h2>Lista de Cuentos (Protegida)</h2>`
+  template: `<app-cuentos-grid></app-cuentos-grid>`
 })
 export class CuentosComponent {}


### PR DESCRIPTION
## Summary
- add lazy-loaded `/cuentos` route
- link "Cuentos" in the navbar
- display the cuentos grid in the cuentos page

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b9400cf48327bb3178549011701e