### PR TITLE
Update admin cuentos list

### DIFF
--- a/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.html
+++ b/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.html
@@ -1,19 +1,12 @@
 <div class="cuentos-container">
-    <h2>Gestión de Cuentos</h2>
-    <div class="cuentos-grid">
-      <!-- <app-cuento-card *ngFor="let cuento of cuentos" [cuento]="cuento"></app-cuento-card> -->
-    </div>
-    <div class="cuento-card">
-      <div *ngFor="let cuento of cuentos">
-        <img [src]="cuento.imagenUrl || 'assets/placeholder-cuento.jpg'" alt="{{cuento.titulo}}" (error)="cargarImagenPlaceholder($event)">
-        <h3>{{ cuento.titulo }}</h3>
-        <p>{{ cuento.autor }}</p>
-      
-        <div class="acciones">
-          <button (click)="verDetalle(cuento.id)">Ver detalle</button>
-        </div>
-  
-      </div>
-    </div>
+  <h2>Gestión de Cuentos</h2>
+  <div class="grid-cuentos">
+    <app-cuento-card
+      *ngFor="let cuento of cuentos"
+      [cuento]="cuento"
+      (agregar)="agregarAlCarrito($event)"
+      (detalle)="verDetalle(cuento.id)"
+    ></app-cuento-card>
   </div>
+</div>
   

--- a/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.scss
+++ b/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.scss
@@ -72,3 +72,11 @@
     cursor: pointer;
   }
 }
+
+.grid-cuentos {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1.5rem;
+  padding: 2rem;
+  background-color: #fffaf0;
+}

--- a/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.ts
+++ b/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.ts
@@ -1,7 +1,8 @@
-import { Component, EventEmitter, OnInit } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { Cuento } from '../../../../model/cuento.model';
 import { CuentoService } from '../../../../services/cuento.service';
 import { Router } from '@angular/router';
+import { CartService } from '../../../../services/carrito.service';
 
 @Component({
   selector: 'app-admin-cuentos',
@@ -11,8 +12,12 @@ import { Router } from '@angular/router';
 export class AdminCuentosComponent implements OnInit {
   cuentos: Cuento[] = [];
   cargandoImagen: boolean = true; // 🔥 Nueva bandera para el skeleton
-  
-  constructor(private cuentoService: CuentoService,private router: Router) {}
+
+  constructor(
+    private cuentoService: CuentoService,
+    private cartService: CartService,
+    private router: Router
+  ) {}
 
   ngOnInit(): void {
     this.cuentoService.obtenerCuentos().subscribe(data => {
@@ -31,5 +36,9 @@ export class AdminCuentosComponent implements OnInit {
   }
   verDetalle(id: number) {
     this.router.navigate(['/cuento', id]);
+  }
+
+  agregarAlCarrito(cuento: Cuento): void {
+    this.cartService.addItem(cuento);
   }
 }


### PR DESCRIPTION
## Summary
- render cuentos grid in the admin section
- support adding to cart from the admin list
- apply grid styling for cuento cards

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847bbe7c8ec832783da826c40eb2df2