### PR TITLE
Add admin recent orders view

### DIFF
--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
@@ -1,1 +1,29 @@
-<p>admin-pedidos works!</p>
+<div class="admin-pedidos-container">
+  <h2>Pedidos Recientes</h2>
+
+  <div *ngIf="isLoading">Cargando pedidos...</div>
+  <div *ngIf="errorMensaje">{{ errorMensaje }}</div>
+
+  <table *ngIf="!isLoading && !errorMensaje">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Fecha/Hora</th>
+        <th>Total</th>
+        <th>Estado Pago</th>
+        <th>Tipo Pago</th>
+        <th>Correo</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let pedido of pedidos">
+        <td>{{ pedido.Id }}</td>
+        <td>{{ pedido.fecha | date:'dd/MM/yyyy HH:mm' }}</td>
+        <td>{{ pedido.total | currency:'USD':'symbol':'1.2-2' }}</td>
+        <td>{{ pedido.estado }}</td>
+        <td>{{ pedido.tipoPago || 'N/A' }}</td>
+        <td>{{ pedido.correo }}</td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.scss
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.scss
@@ -1,0 +1,18 @@
+.admin-pedidos-container {
+  padding: 1rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+th, td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+}
+
+th {
+  background-color: #f2f2f2;
+}

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
@@ -1,12 +1,35 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { PedidoService } from '../../../../services/pedido.service';
+import { Pedido } from '../../../../model/pedido.model';
 
 @Component({
   selector: 'app-admin-pedidos',
-  // standalone: true,
-  // imports: [],
+  standalone: true,
+  imports: [CommonModule],
   templateUrl: './admin-pedidos.component.html',
   styleUrl: './admin-pedidos.component.scss'
 })
-export class AdminPedidosComponent {
+export class AdminPedidosComponent implements OnInit {
+  pedidos: Pedido[] = [];
+  isLoading = true;
+  errorMensaje: string | null = null;
 
+  constructor(private pedidoService: PedidoService) {}
+
+  ngOnInit(): void {
+    this.pedidoService.getOrders().subscribe({
+      next: data => {
+        this.pedidos = data
+          .sort((a, b) => new Date(b.fecha).getTime() - new Date(a.fecha).getTime())
+          .slice(0, 5);
+        this.isLoading = false;
+      },
+      error: err => {
+        console.error('Error fetching orders:', err);
+        this.errorMensaje = 'No se pudieron cargar los pedidos';
+        this.isLoading = false;
+      }
+    });
+  }
 }

--- a/src/app/model/pedido.model.ts
+++ b/src/app/model/pedido.model.ts
@@ -17,6 +17,7 @@ export interface Pedido {
   items: PedidoItem[];
   total: number;
   estado: string; // ejemplo: 'PAGO_PENDIENTE', 'PAGADO', 'ENVIADO', 'ENTREGADO'
+  tipoPago?: string;
   userId: number;
   correoUsuario: string;
 }


### PR DESCRIPTION
## Summary
- extend `Pedido` model with `tipoPago`
- implement admin page to list latest five orders

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f1546aa88327adc267d4b4c9ed70