### PR TITLE
Implement cuento management

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -7,7 +7,7 @@ import { RouterOutlet } from '@angular/router';
   standalone: true,
   imports: [RouterOutlet,],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.scss'
+  styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   title = 'cuentos-killa-FE';

--- a/src/app/components/cart-modal/cart-modal.component.ts
+++ b/src/app/components/cart-modal/cart-modal.component.ts
@@ -10,7 +10,7 @@ import { CommonModule } from '@angular/common';
   imports: [CommonModule, // 🔥 necesario para *ngIf, *ngFor
   ],
   templateUrl: './cart-modal.component.html',
-  styleUrl: './cart-modal.component.scss',
+  styleUrls: ['./cart-modal.component.scss'],
   
 })
 export class CartModalComponent implements OnInit {

--- a/src/app/components/cart/cart.component.ts
+++ b/src/app/components/cart/cart.component.ts
@@ -8,7 +8,7 @@ import { CommonModule } from '@angular/common';
   standalone: true,
   imports: [CommonModule],
   templateUrl: './cart.component.html',
-  styleUrl: './cart.component.scss'
+  styleUrls: ['./cart.component.scss']
 })
 
 export class CartComponent implements OnInit {

--- a/src/app/components/confirm-dialog/confirm-dialog.component.html
+++ b/src/app/components/confirm-dialog/confirm-dialog.component.html
@@ -1,0 +1,9 @@
+<div class="overlay">
+  <div class="dialog">
+    <p>{{ message }}</p>
+    <div class="buttons">
+      <button class="confirm" (click)="onConfirm()">Sí</button>
+      <button class="cancel" (click)="onCancel()">Cancelar</button>
+    </div>
+  </div>
+</div>

--- a/src/app/components/confirm-dialog/confirm-dialog.component.scss
+++ b/src/app/components/confirm-dialog/confirm-dialog.component.scss
@@ -1,0 +1,44 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.dialog {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 8px;
+  text-align: center;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+}
+
+.buttons {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+button.confirm {
+  background-color: #28a745;
+  color: #fff;
+}
+
+button.cancel {
+  background-color: #dc3545;
+  color: #fff;
+}

--- a/src/app/components/confirm-dialog/confirm-dialog.component.ts
+++ b/src/app/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,20 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-confirm-dialog',
+  templateUrl: './confirm-dialog.component.html',
+  styleUrls: ['./confirm-dialog.component.scss']
+})
+export class ConfirmDialogComponent {
+  @Input() message = '';
+  @Output() confirm = new EventEmitter<void>();
+  @Output() cancel = new EventEmitter<void>();
+
+  onConfirm(): void {
+    this.confirm.emit();
+  }
+
+  onCancel(): void {
+    this.cancel.emit();
+  }
+}

--- a/src/app/components/cuento-card/cuento-card.component.html
+++ b/src/app/components/cuento-card/cuento-card.component.html
@@ -7,7 +7,7 @@
 
   <div class="acciones">
     <button (click)="verDetalle()">Ver detalle</button>
-    <button (click)="agregarAlCarrito()">Agregar al carrito</button>
+    <button *ngIf="!isAdmin" (click)="agregarAlCarrito()">Agregar al carrito</button>
     <ng-container *ngIf="isAdmin">
       <button (click)="editarCuento()" class="admin-button editar">Editar</button>
       <button (click)="deshabilitarCuento()" class="admin-button deshabilitar">Deshabilitar</button>

--- a/src/app/components/cuento-card/cuento-card.component.scss
+++ b/src/app/components/cuento-card/cuento-card.component.scss
@@ -15,7 +15,9 @@
   .acciones {
     margin-top: 0.5rem;
     display: flex;
-    justify-content: space-around;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 
     // Estilos para botones de admin
     button.admin-button { // More specific selector

--- a/src/app/components/cuentos-grid/cuentos-grid.component.ts
+++ b/src/app/components/cuentos-grid/cuentos-grid.component.ts
@@ -7,8 +7,7 @@ import { CartService } from '../../services/carrito.service';
 @Component({
   selector: 'app-cuentos-grid',
   templateUrl: './cuentos-grid.component.html',
-  styleUrls: ['./cuentos-grid.component.scss'
-  ],
+  styleUrls: ['./cuentos-grid.component.scss'],
 })
 
 export class CuentosGridComponent implements OnInit {

--- a/src/app/components/layout/layout.component.ts
+++ b/src/app/components/layout/layout.component.ts
@@ -8,7 +8,7 @@ import { NavbarComponent } from '../navbar/navbar.component';
   standalone: true,
   imports: [RouterOutlet,NavbarComponent],
   templateUrl: './layout.component.html',
-  styleUrl: './layout.component.scss'  
+  styleUrls: ['./layout.component.scss']
 })
 export class LayoutComponent {
 

--- a/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.html
+++ b/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.html
@@ -19,4 +19,11 @@
     ></app-cuento-card>
     <!-- (agregar) ya no se maneja aquí, sino dentro de la tarjeta si es necesario -->
   </div>
+
+  <app-confirm-dialog
+    *ngIf="cuentoParaDeshabilitar"
+    [message]="'¿Desea dar de baja el cuento?'"
+    (confirm)="confirmarDeshabilitar()"
+    (cancel)="cancelarDeshabilitar()">
+  </app-confirm-dialog>
 </div>

--- a/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.ts
+++ b/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.ts
@@ -7,11 +7,12 @@ import { Router } from '@angular/router';
 @Component({
   selector: 'app-admin-cuentos',
   templateUrl: './admin-cuentos.component.html',
-  styleUrl: './admin-cuentos.component.scss'
+  styleUrls: ['./admin-cuentos.component.scss']
 })
 export class AdminCuentosComponent implements OnInit {
   // @Input() cuento!: Cuento; // This Input seems unused here, more for a detail/card component
   cuentos: Cuento[] = [];
+  cuentoParaDeshabilitar: Cuento | null = null;
   // cargandoImagen: boolean = true; // This logic is now in CuentoCardComponent
 
   constructor(
@@ -47,24 +48,29 @@ export class AdminCuentosComponent implements OnInit {
 
   // --- Funciones para Admin ---
   abrirModalAgregarCuento(): void {
-    console.log('Abrir modal para agregar nuevo cuento');
-    // Aquí se implementará la lógica para abrir un modal/dialogo con el formulario
-    // Por ahora, podemos navegar a una ruta si el formulario es una página separada
-    // this.router.navigate(['/admin/cuentos/nuevo']);
+    this.router.navigate(['/admin/cuentos/nuevo']);
   }
 
   editarCuento(cuento: Cuento): void {
-    console.log('Editar cuento:', cuento);
-    // Aquí se implementará la lógica para abrir un modal/dialogo con el formulario
-    // precargado con los datos del cuento.
-    // O navegar a una ruta como '/admin/cuentos/editar', cuento.id]);
-    // this.router.navigate(['/admin/cuentos/editar', cuento.id]);
+    this.router.navigate(['/admin/cuentos/editar', cuento.id]);
   }
 
   deshabilitarCuento(cuento: Cuento): void {
-    console.log('Deshabilitar cuento:', cuento);
-    // Aquí se implementará la lógica para llamar al servicio y deshabilitar el cuento.
-    // Se podría mostrar una confirmación antes de proceder.
-    // Ejemplo: if (confirm(`¿Está seguro de que desea deshabilitar "${cuento.titulo}"?`)) { ... }
+    this.cuentoParaDeshabilitar = cuento;
+  }
+
+  confirmarDeshabilitar(): void {
+    if (!this.cuentoParaDeshabilitar) return;
+    const id = this.cuentoParaDeshabilitar.id;
+    this.cuentoService.deshabilitarCuento(id, false).subscribe(() => {
+      this.cuentos = this.cuentos.map(c =>
+        c.id === id ? { ...c, habilitado: false } : c
+      );
+      this.cuentoParaDeshabilitar = null;
+    });
+  }
+
+  cancelarDeshabilitar(): void {
+    this.cuentoParaDeshabilitar = null;
   }
 }

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.ts
@@ -9,7 +9,7 @@ import { UserService } from '../../../../services/user.service';
   // standalone: true,
   // imports: [],
   templateUrl: './admin-dashboard.component.html',
-  styleUrl: './admin-dashboard.component.scss'
+  styleUrls: ['./admin-dashboard.component.scss']
 })
 export class AdminDashboardComponent implements OnInit {
   cuentosPublicados = 0;

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
@@ -6,7 +6,7 @@ import { RouterModule } from '@angular/router';
   // standalone: true,
   // imports: [RouterModule],
   templateUrl: './admin-layout.component.html',
-  styleUrl: './admin-layout.component.scss'
+  styleUrls: ['./admin-layout.component.scss']
 })
 export class AdminLayoutComponent {
 

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
@@ -8,7 +8,7 @@ import { Pedido } from '../../../../model/pedido.model';
   // standalone: true,
   // imports: [CommonModule],
   templateUrl: './admin-pedidos.component.html',
-  styleUrl: './admin-pedidos.component.scss'
+  styleUrls: ['./admin-pedidos.component.scss']
 })
 export class AdminPedidosComponent implements OnInit {
   pedidos: Pedido[] = [];

--- a/src/app/components/pages/admin/admin-usuarios/admin-usuarios.component.ts
+++ b/src/app/components/pages/admin/admin-usuarios/admin-usuarios.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
   // standalone: true,
   // imports: [],
   templateUrl: './admin-usuarios.component.html',
-  styleUrl: './admin-usuarios.component.scss'
+  styleUrls: ['./admin-usuarios.component.scss']
 })
 export class AdminUsuariosComponent {
 

--- a/src/app/components/pages/admin/admin.module.ts
+++ b/src/app/components/pages/admin/admin.module.ts
@@ -2,7 +2,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
-import { FormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 // import { HttpClientModule } from '@angular/common/http';
 
 import { AdminLayoutComponent } from './admin-layout/admin-layout.component';
@@ -10,6 +10,8 @@ import { AdminDashboardComponent } from './admin-dashboard/admin-dashboard.compo
 import { AdminCuentosComponent } from './admin-cuentos/admin-cuentos.component';
 import { AdminPedidosComponent } from './admin-pedidos/admin-pedidos.component';
 import { AdminUsuariosComponent } from './admin-usuarios/admin-usuarios.component';
+import { CuentoFormComponent } from './cuento-form/cuento-form.component';
+import { ConfirmDialogComponent } from '../../confirm-dialog/confirm-dialog.component';
 import { SharedModule } from "../../shared.module";
 
 // import { SharedModule } from '../../shared.module'; 
@@ -23,6 +25,8 @@ const routes: Routes = [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
       { path: 'dashboard', component: AdminDashboardComponent },
       { path: 'cuentos', component: AdminCuentosComponent },
+      { path: 'cuentos/nuevo', component: CuentoFormComponent },
+      { path: 'cuentos/editar/:id', component: CuentoFormComponent },
       { path: 'pedidos', component: AdminPedidosComponent },
       { path: 'usuarios', component: AdminUsuariosComponent },
     ]
@@ -35,11 +39,14 @@ const routes: Routes = [
     AdminDashboardComponent,
     AdminCuentosComponent,
     AdminPedidosComponent,
-    AdminUsuariosComponent
+    AdminUsuariosComponent,
+    CuentoFormComponent,
+    ConfirmDialogComponent
   ],
   imports: [
     CommonModule,
     FormsModule,
+    ReactiveFormsModule,
     // HttpClientModule,
     RouterModule,
     RouterModule.forChild(routes),

--- a/src/app/components/pages/admin/cuento-form/cuento-form.component.ts
+++ b/src/app/components/pages/admin/cuento-form/cuento-form.component.ts
@@ -1,11 +1,92 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+import { CuentoService } from '../../../../services/cuento.service';
+import { Cuento } from '../../../../model/cuento.model';
 
 @Component({
   selector: 'app-cuento-form',
-  imports: [],
   templateUrl: './cuento-form.html',
-  styleUrl: './cuento-form.scss'
+  styleUrls: ['./cuento-form.scss']
 })
-export class CuentoForm {
+export class CuentoFormComponent implements OnInit {
+  cuentoForm!: FormGroup;
+  isEditMode = false;
+  cuentoId?: number;
+  imagePreview: string | null = null;
+  selectedFile?: File;
 
+  constructor(
+    private fb: FormBuilder,
+    private route: ActivatedRoute,
+    private router: Router,
+    private cuentoService: CuentoService
+  ) {}
+
+  ngOnInit(): void {
+    this.cuentoForm = this.fb.group({
+      titulo: ['', Validators.required],
+      autor: ['', Validators.required],
+      descripcionCorta: ['', Validators.required],
+      editorial: [''],
+      tipoEdicion: [''],
+      nroPaginas: ['', Validators.required],
+      fechaPublicacion: [''],
+      edadRecomendada: [''],
+      stock: ['', Validators.required],
+      precio: ['', Validators.required]
+    });
+
+    const idParam = this.route.snapshot.paramMap.get('id');
+    if (idParam) {
+      this.isEditMode = true;
+      this.cuentoId = +idParam;
+      this.cuentoService.getCuentoById(this.cuentoId).subscribe(c => {
+        this.cuentoForm.patchValue({
+          titulo: c.titulo,
+          autor: c.autor,
+          descripcionCorta: c.descripcionCorta,
+          editorial: c.editorial,
+          tipoEdicion: c.tipoEdicion,
+          nroPaginas: c.nroPaginas,
+          fechaPublicacion: c.fechaPublicacion,
+          edadRecomendada: c.edadRecomendada,
+          stock: c.stock,
+          precio: c.precio
+        });
+        this.imagePreview = c.imagenUrl;
+      });
+    }
+  }
+
+  onFileChange(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      this.selectedFile = input.files[0];
+      const reader = new FileReader();
+      reader.onload = e => (this.imagePreview = reader.result as string);
+      reader.readAsDataURL(this.selectedFile);
+    }
+  }
+
+  guardar(): void {
+    if (this.cuentoForm.invalid) return;
+    const formData = new FormData();
+    Object.entries(this.cuentoForm.value).forEach(([key, value]) => {
+      formData.append(key, value as any);
+    });
+    if (this.selectedFile) {
+      formData.append('imagen', this.selectedFile);
+    }
+
+    const request$ = this.isEditMode && this.cuentoId
+      ? this.cuentoService.actualizarCuento(this.cuentoId, formData)
+      : this.cuentoService.crearCuento(formData);
+
+    request$.subscribe(() => this.router.navigate(['/admin/cuentos']));
+  }
+
+  cancelar(): void {
+    this.router.navigate(['/admin/cuentos']);
+  }
 }

--- a/src/app/components/pages/admin/cuento-form/cuento-form.html
+++ b/src/app/components/pages/admin/cuento-form/cuento-form.html
@@ -1,1 +1,58 @@
-<p>cuento-form works!</p>
+<div class="form-container">
+  <h2>{{ isEditMode ? 'Editar Cuento' : 'Nuevo Cuento' }}</h2>
+
+  <form [formGroup]="cuentoForm" (ngSubmit)="guardar()" class="cuento-form">
+    <div class="campos-basicos">
+      <label>
+        Título
+        <input type="text" formControlName="titulo" required />
+      </label>
+      <label>
+        Autor
+        <input type="text" formControlName="autor" required />
+      </label>
+      <label class="descripcion">
+        Descripción
+        <textarea formControlName="descripcionCorta" required></textarea>
+      </label>
+      <label>
+        Editorial
+        <input type="text" formControlName="editorial" />
+      </label>
+      <label>
+        Tipo de Edición
+        <input type="text" formControlName="tipoEdicion" />
+      </label>
+      <label>
+        Número de Páginas
+        <input type="number" formControlName="nroPaginas" required />
+      </label>
+      <label>
+        Fecha de Publicación
+        <input type="date" formControlName="fechaPublicacion" />
+      </label>
+      <label>
+        Edad Recomendada
+        <input type="text" formControlName="edadRecomendada" />
+      </label>
+      <label>
+        Stock
+        <input type="number" formControlName="stock" required />
+      </label>
+      <label>
+        Precio
+        <input type="number" formControlName="precio" required />
+      </label>
+      <label class="imagen">
+        Imagen
+        <input type="file" (change)="onFileChange($event)" />
+      </label>
+      <img *ngIf="imagePreview" [src]="imagePreview" class="preview" />
+    </div>
+
+    <div class="acciones">
+      <button type="submit" class="aceptar">{{ isEditMode ? 'Actualizar' : 'Crear' }}</button>
+      <button type="button" class="cancelar" (click)="cancelar()">Cancelar</button>
+    </div>
+  </form>
+</div>

--- a/src/app/components/pages/admin/cuento-form/cuento-form.scss
+++ b/src/app/components/pages/admin/cuento-form/cuento-form.scss
@@ -1,0 +1,65 @@
+.form-container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+
+.cuento-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  .campos-basicos {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+
+  label {
+    display: flex;
+    flex-direction: column;
+    font-weight: 500;
+  }
+
+  input,
+  textarea {
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    border-radius: 6px;
+  }
+
+  .descripcion,
+  .imagen {
+    grid-column: span 2;
+  }
+
+  .acciones {
+    display: flex;
+    gap: 1rem;
+    justify-content: flex-end;
+
+    button {
+      padding: 0.5rem 1rem;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+    }
+
+    .aceptar {
+      background-color: #28a745;
+      color: #fff;
+    }
+
+    .cancelar {
+      background-color: #dc3545;
+      color: #fff;
+    }
+  }
+}
+
+.preview {
+  max-width: 200px;
+  margin-top: 0.5rem;
+  border-radius: 6px;
+}

--- a/src/app/components/pages/pago/pago.component.ts
+++ b/src/app/components/pages/pago/pago.component.ts
@@ -9,7 +9,7 @@ import { PagoService } from '../../../services/pago.service'; // Added PagoServi
   standalone: true,
   imports: [RouterModule, CommonModule],
   templateUrl: './pago.component.html',
-  styleUrl: './pago.component.scss'
+  styleUrls: ['./pago.component.scss']
 })
 export class PagoComponent implements OnInit {
   pedidoId: number = 0;

--- a/src/app/components/pages/voucher/voucher.component.ts
+++ b/src/app/components/pages/voucher/voucher.component.ts
@@ -5,7 +5,7 @@ import { Component } from '@angular/core';
   standalone: true,
   imports: [],
   templateUrl: './voucher.component.html',
-  styleUrl: './voucher.component.scss'
+  styleUrls: ['./voucher.component.scss']
 })
 export class VoucherComponent {
 


### PR DESCRIPTION
## Summary
- add admin cuento form component
- add confirmation dialog component
- hook up admin cuentos actions to new routes and dialog
- improve button layout in cuento cards
- hide add-to-cart for admins and style cuento form buttons
- fix `styleUrls` definitions across components

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862b50f98508327bc080655319c826a