### PR TITLE
Switch cuento form to JSON payload

### DIFF
--- a/src/app/components/pages/admin/cuento-form/cuento-form.component.ts
+++ b/src/app/components/pages/admin/cuento-form/cuento-form.component.ts
@@ -15,6 +15,7 @@ export class CuentoFormComponent implements OnInit {
   cuentoId?: number;
   imagePreview: string | null = null;
   selectedFile?: File;
+  imagenBase64: string | null = null;
 
   constructor(
     private fb: FormBuilder,
@@ -64,24 +65,26 @@ export class CuentoFormComponent implements OnInit {
     if (input.files && input.files.length > 0) {
       this.selectedFile = input.files[0];
       const reader = new FileReader();
-      reader.onload = e => (this.imagePreview = reader.result as string);
+      reader.onload = () => {
+        this.imagePreview = reader.result as string;
+        this.imagenBase64 = reader.result as string;
+      };
       reader.readAsDataURL(this.selectedFile);
     }
   }
 
   guardar(): void {
     if (this.cuentoForm.invalid) return;
-    const formData = new FormData();
-    Object.entries(this.cuentoForm.value).forEach(([key, value]) => {
-      formData.append(key, value as any);
-    });
-    if (this.selectedFile) {
-      formData.append('imagen', this.selectedFile);
+    const cuentoData: Partial<Cuento> = {
+      ...this.cuentoForm.value
+    };
+    if (this.imagenBase64) {
+      cuentoData.imagenUrl = this.imagenBase64;
     }
 
     const request$ = this.isEditMode && this.cuentoId
-      ? this.cuentoService.actualizarCuento(this.cuentoId, formData)
-      : this.cuentoService.crearCuento(formData);
+      ? this.cuentoService.actualizarCuento(this.cuentoId, cuentoData)
+      : this.cuentoService.crearCuento(cuentoData);
 
     request$.subscribe(() => this.router.navigate(['/admin/cuentos']));
   }

--- a/src/app/services/cuento.service.ts
+++ b/src/app/services/cuento.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http'; // Import HttpHeaders
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Cuento } from '../model/cuento.model';
 import { environment } from '../../environments/environment';
@@ -19,14 +19,13 @@ export class CuentoService {
   }
 
   // POST: /api/cuentos
-  crearCuento(cuentoData: FormData): Observable<Cuento> {
-    // No es necesario establecer Content-Type: multipart/form-data manualmente.
-    // Angular HttpClient lo hace automáticamente cuando el cuerpo es FormData.
+  crearCuento(cuentoData: Partial<Cuento>): Observable<Cuento> {
+    // El backend ahora espera un JSON con los datos del cuento.
     return this.http.post<Cuento>(this.apiUrl, cuentoData);
   }
 
   // PUT: /api/cuentos/{id}
-  actualizarCuento(id: number, cuentoData: FormData): Observable<Cuento> {
+  actualizarCuento(id: number, cuentoData: Partial<Cuento>): Observable<Cuento> {
     return this.http.put<Cuento>(`${this.apiUrl}/${id}`, cuentoData);
   }
 


### PR DESCRIPTION
## Summary
- send JSON from `CuentoFormComponent` instead of `FormData`
- adjust `CuentoService` to accept JSON payloads

## Testing
- `npm test --silent` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6862f109f9f08327bdd33037bc5a0572