### PR TITLE
Improve PagoComponent UI messages

### DIFF
--- a/src/app/components/pages/pago/pago.component.html
+++ b/src/app/components/pages/pago/pago.component.html
@@ -3,6 +3,14 @@
   <p>Tu número de pedido es: <span class="font-semibold">#{{ pedidoId }}</span></p>
   <p>Estado del pedido: <span class="font-semibold">{{ orderStatus }}</span></p>
 
+  <div *ngIf="mensaje" [ngClass]="{
+        'success-mensaje': mensajeTipo === 'success',
+        'error-mensaje': mensajeTipo === 'error',
+        'info-mensaje': mensajeTipo === 'info'
+      }" class="mensaje">
+    <p>{{ mensaje }}</p>
+  </div>
+
   <div *ngIf="orderStatus === 'Pago Verificado'" class="payment-success-message">
     <p>Tu pago ha sido verificado exitosamente.</p>
   </div>

--- a/src/app/components/pages/pago/pago.component.scss
+++ b/src/app/components/pages/pago/pago.component.scss
@@ -153,3 +153,39 @@
     cursor: pointer;
   }
 }
+
+.mensaje {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 1rem;
+}
+
+.success-mensaje {
+  background-color: #d4edda;
+  color: #155724;
+  border: 1px solid #c3e6cb;
+}
+
+.error-mensaje {
+  background-color: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c6cb;
+}
+
+.info-mensaje {
+  background-color: #d1ecf1;
+  color: #0c5460;
+  border: 1px solid #bee5eb;
+}
+
+.btn-confirmar {
+  background-color: #ffad60;
+  color: #fff;
+  border: none;
+}
+
+.btn-confirmar:hover {
+  background-color: #ffaa40;
+}

--- a/src/app/components/pages/pago/pago.component.spec.ts
+++ b/src/app/components/pages/pago/pago.component.spec.ts
@@ -59,8 +59,6 @@ describe('PagoComponent', () => {
     component = fixture.componentInstance;
     // fixture.detectChanges(); // We'll call this in each test or after setting queryParams
 
-    // Spy on window.alert
-    spyOn(window, 'alert').and.stub();
     // Spy on console.log and console.error
     spyOn(console, 'log').and.stub();
     spyOn(console, 'error').and.stub();
@@ -102,7 +100,8 @@ describe('PagoComponent', () => {
 
       expect(mockPagoService.confirmarPagoMercadoPago).toHaveBeenCalledWith(1);
       expect(component.orderStatus).toBe('Pago Verificado');
-      expect(window.alert).toHaveBeenCalledWith('¡Pago con Mercado Pago confirmado exitosamente! Estado del pedido actualizado a Pago Verificado.');
+      expect(component.mensaje).toBe('¡Pago con Mercado Pago confirmado exitosamente! Estado del pedido actualizado a Pago Verificado.');
+      expect(component.mensajeTipo).toBe('success');
       expect(mockPedidoService.getOrderStatus).toHaveBeenCalledTimes(2); // Initial + after MP confirmation
     }));
 
@@ -116,12 +115,13 @@ describe('PagoComponent', () => {
       tick();
 
       expect(mockPagoService.confirmarPagoMercadoPago).toHaveBeenCalledWith(1);
-      expect(window.alert).toHaveBeenCalledWith('Error al confirmar el pago con Mercado Pago. Por favor, contacta a soporte.');
+      expect(component.mensaje).toBe('Error al confirmar el pago con Mercado Pago. Por favor, contacta a soporte.');
+      expect(component.mensajeTipo).toBe('error');
       expect(component.orderStatus).not.toBe('Pago Verificado'); // or check it remains initial/fetched one
       expect(mockPedidoService.getOrderStatus).toHaveBeenCalledTimes(2); // Initial + after MP error
     }));
 
-    it('should alert and fetch status if payment status is not "approved" but external_reference matches', fakeAsync(() => {
+    it('should show info message if payment status is not "approved" but external_reference matches', fakeAsync(() => {
       mockActivatedRoute.setQueryParamMap({
         status: 'pending', // General status from MP
         collection_status: 'pending', // More specific status
@@ -131,7 +131,8 @@ describe('PagoComponent', () => {
       tick();
 
       expect(mockPagoService.confirmarPagoMercadoPago).not.toHaveBeenCalled();
-      expect(window.alert).toHaveBeenCalledWith('El pago con Mercado Pago está pending.');
+      expect(component.mensaje).toBe('El pago con Mercado Pago está pending.');
+      expect(component.mensajeTipo).toBe('info');
       expect(mockPedidoService.getOrderStatus).toHaveBeenCalledTimes(2); // Initial + after MP pending
     }));
     
@@ -156,9 +157,8 @@ describe('PagoComponent', () => {
       tick();
 
       expect(mockPagoService.confirmarPagoMercadoPago).not.toHaveBeenCalled();
-       // The component logic also checks for 'status' if 'collection_status' isn't 'approved'.
-       // If status is also not 'approved' (e.g. 'rejected'), it alerts.
-      expect(window.alert).toHaveBeenCalledWith('El pago con Mercado Pago está rejected.');
+      expect(component.mensaje).toBe('El pago con Mercado Pago está rejected.');
+      expect(component.mensajeTipo).toBe('info');
       expect(component.orderStatus).toBe('PENDIENTE DE PAGO'); // Stays initial
     }));
 
@@ -201,15 +201,17 @@ describe('PagoComponent', () => {
       component.uploadVoucher();
       
       expect(mockPedidoService.uploadVoucher).toHaveBeenCalledWith(1, mockFile);
-      expect(window.alert).toHaveBeenCalledWith('Voucher subido exitosamente. El estado del pedido se actualizará en breve.');
+      expect(component.mensaje).toBe('Voucher subido exitosamente. El estado del pedido se actualizará en breve.');
+      expect(component.mensajeTipo).toBe('success');
       expect(component.orderStatus).toBe('Confirmación de Pago Enviada'); // Temporary status
       expect(mockPedidoService.getOrderStatus).toHaveBeenCalledTimes(1); // Assuming initial fetch + this one
     });
 
-    it('uploadVoucher should alert if no file is selected', () => {
+    it('uploadVoucher should show error message if no file is selected', () => {
       component.selectedFile = null;
       component.uploadVoucher();
-      expect(window.alert).toHaveBeenCalledWith('Por favor, selecciona un archivo de voucher.');
+      expect(component.mensaje).toBe('Por favor, selecciona un archivo de voucher.');
+      expect(component.mensajeTipo).toBe('error');
       expect(mockPedidoService.uploadVoucher).not.toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
## Summary
- enhance PagoComponent with dynamic on–screen messages
- style messages and confirm button for user mode
- adjust tests for new message system

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fa0111bc8327a8ed6bfe15c6b1cd