### PR TITLE
Show full order details in admin

### DIFF
--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
@@ -1,5 +1,5 @@
 <div class="admin-pedidos-container">
-  <h2>Pedidos Recientes</h2>
+  <h2>Listado de Pedidos</h2>
 
   <div *ngIf="isLoading">Cargando pedidos...</div>
   <div *ngIf="errorMensaje">{{ errorMensaje }}</div>
@@ -9,20 +9,26 @@
       <tr>
         <th>ID</th>
         <th>Fecha/Hora</th>
-        <th>Total</th>
+        <th>Nombre</th>
+        <th>Correo</th>
+        <th>Dirección</th>
+        <th>Teléfono</th>
         <th>Estado Pago</th>
         <th>Tipo Pago</th>
-        <th>Correo</th>
+        <th>Total</th>
       </tr>
     </thead>
     <tbody>
       <tr *ngFor="let pedido of pedidos">
-        <td>{{ pedido.Id }}</td>
+        <td>{{ pedido.Id || pedido.id }}</td>
         <td>{{ pedido.fecha | date:'dd/MM/yyyy HH:mm' }}</td>
-        <td>{{ pedido.total | currency:'USD':'symbol':'1.2-2' }}</td>
+        <td>{{ pedido.nombre }}</td>
+        <td>{{ pedido.correo }}</td>
+        <td>{{ pedido.direccion }}</td>
+        <td>{{ pedido.telefono }}</td>
         <td>{{ pedido.estado }}</td>
         <td>{{ pedido.tipoPago || 'N/A' }}</td>
-        <td>{{ pedido.correo }}</td>
+        <td>{{ pedido.total | currency:'USD':'symbol':'1.2-2' }}</td>
       </tr>
     </tbody>
   </table>

--- a/src/app/model/pedido.model.ts
+++ b/src/app/model/pedido.model.ts
@@ -8,7 +8,10 @@ export interface PedidoItem {
 }
 
 export interface Pedido {
+  /** Identificador único del pedido. El backend puede devolverlo como
+   *  `Id` o `id`, por lo que ambos campos se mantienen para compatibilidad. */
   Id: number;
+  id?: number;
   fecha: string; // O Date, dependiendo de la API
   nombre: string;
   correo: string;


### PR DESCRIPTION
## Summary
- include `id` as optional in `Pedido` model for compatibility
- extend admin orders table to list all order info

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862fbaab4e88327a135eddbde39b49c