### PR TITLE
Improve payment UX

### DIFF
--- a/src/app/components/pages/pago/pago.component.html
+++ b/src/app/components/pages/pago/pago.component.html
@@ -23,22 +23,49 @@
     <h3>Selecciona tu método de pago:</h3>
     <div class="payment-buttons-row">
       <div class="custom-file-upload">
-        <input type="file" id="voucherFile" (change)="onFileSelected($event)" hidden />
+        <input
+          type="file"
+          id="voucherFile"
+          accept="image/*,application/pdf"
+          (change)="onFileSelected($event)"
+          hidden
+        />
         <label for="voucherFile" class="file-label">
           📎 Seleccionar comprobante
         </label>
         <br />
         <span class="file-name">{{ nombreArchivo || 'Sin archivos seleccionados' }}</span>
+        <div class="preview" *ngIf="previewUrl">
+          <img *ngIf="isImage" [src]="previewUrl" alt="Vista previa" class="thumbnail" />
+          <span *ngIf="isPdf" class="material-icons pdf-icon">picture_as_pdf</span>
+        </div>
       </div>
-      <button (click)="uploadVoucher()" class="btn-killa btn-confirmar" [disabled]="!selectedFile">
+      <button
+        (click)="uploadVoucher()"
+        class="btn-killa btn-confirmar"
+        [disabled]="!selectedFile || isUploading"
+      >
         Confirmar Subida
+        <span *ngIf="isUploading" class="spinner"></span>
       </button>
 
       <div class="payment-options">
-        <button (click)="pagarConMercadoPago()" class="btn-killa btn-mercado">
+        <button (click)="openMercadoPagoModal()" class="btn-killa btn-mercado">
           Pagar con Mercado Pago
         </button>
       </div>
+    </div>
+  </div>
+</div>
+
+<div class="overlay" *ngIf="showMercadoModal">
+  <div class="mercado-modal">
+    <h3>Pagar con Mercado Pago</h3>
+    <p>Monto a pagar: {{ orderTotal | currency:'USD':'symbol':'1.2-2' }}</p>
+    <p>Tu estado cambiará a 'Pago Verificado' en 1–2 minutos tras la transacción.</p>
+    <div class="modal-buttons">
+      <button class="btn-killa" (click)="pagarConMercadoPagoConfirmado()">Continuar</button>
+      <button class="btn-killa btn-cancel" (click)="closeMercadoPagoModal()">Cancelar</button>
     </div>
   </div>
 </div>

--- a/src/app/components/pages/pago/pago.component.scss
+++ b/src/app/components/pages/pago/pago.component.scss
@@ -1,12 +1,13 @@
 .container {
-    max-width: 40rem;
-    margin: 3rem auto;
-    padding: 2rem;
-    background-color: #fff;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.05);
-    border-radius: 1rem;
-    text-align: center;
-  }
+  max-width: 40rem;
+  width: 100%;
+  margin: 3rem auto;
+  padding: 2rem;
+  background-color: #fff;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.05);
+  border-radius: 1rem;
+  text-align: center;
+}
   
   .container h2 {
     font-size: 1.75rem;
@@ -38,6 +39,19 @@
       justify-content: center;
     }
   }
+
+@media (max-width: 640px) {
+  .payment-buttons-row {
+    flex-direction: column;
+    align-items: stretch;
+    button {
+      width: 100%;
+    }
+  }
+  .container {
+    margin: 1rem;
+  }
+}
   
   .btn-killa {
     padding: 0.75rem 1.5rem;
@@ -188,4 +202,73 @@
 
 .btn-confirmar:hover {
   background-color: #ffaa40;
+}
+
+.spinner {
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #ffad60;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  animation: spin 1s linear infinite;
+  display: inline-block;
+  margin-left: 8px;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.preview {
+  margin-top: 0.5rem;
+}
+
+.thumbnail {
+  max-width: 100px;
+  max-height: 100px;
+  border-radius: 4px;
+}
+
+.pdf-icon {
+  font-size: 48px;
+  color: #d32f2f;
+}
+
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.mercado-modal {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 8px;
+  text-align: center;
+  max-width: 90%;
+}
+
+.modal-buttons {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.btn-cancel {
+  background-color: #ccc;
+  color: #333;
 }

--- a/src/app/components/pages/pago/pago.component.spec.ts
+++ b/src/app/components/pages/pago/pago.component.spec.ts
@@ -172,23 +172,23 @@ describe('PagoComponent', () => {
     }));
   });
 
-  describe('pagarConMercadoPago', () => {
+describe('pagarConMercadoPagoConfirmado', () => {
     it('should redirect to the correct Mercado Pago URL', () => {
-      component.pedidoId = 5; // Set a pedidoId for the component instance
+      component.pedidoId = 5;
       fixture.detectChanges();
-      
-      component.pagarConMercadoPago();
+
+      component.pagarConMercadoPagoConfirmado();
       // @ts-ignore
       expect(window.location.href).toBe('http://localhost:8080/api/mercado-pago/pagar/5');
     });
   });
   
-  // Example test for onVoucherSelected and uploadVoucher (not part of this subtask but good for completeness)
+  // Example test for onFileSelected and uploadVoucher (not part of this subtask but good for completeness)
   describe('Voucher Upload', () => {
-    it('onVoucherSelected should set selectedFile', () => {
+    it('onFileSelected should set selectedFile', () => {
       const mockFile = new File([''], 'voucher.jpg', { type: 'image/jpeg' });
-      const event = { target: { files: [mockFile] } };
-      component.onVoucherSelected(event);
+      const event = { target: { files: [mockFile] } } as any;
+      component.onFileSelected(event);
       expect(component.selectedFile).toBe(mockFile);
     });
 


### PR DESCRIPTION
## Summary
- add preview, spinner, and modal to `pago` page
- validate file type and size client side
- load order total and show Mercado Pago instructions
- update responsive styles
- adjust unit tests

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630bcfa3088327ac8d91e96601acd4