### PR TITLE
Add orders page for logged user

### DIFF
--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -17,7 +17,7 @@
       <a routerLink="/admin/dashboard" routerLinkActive="active">Admin</a>
     </li>
     <li *ngIf="user">
-      <a routerLink="/pedidos" routerLinkActive="active">Mis Pedidos</a>
+      <a routerLink="/pedidos" routerLinkActive="active">Pedidos</a>
     </li>
     <li *ngIf="!user">
       <button class="btn-login" (click)="openLoginDialog()">Login</button>

--- a/src/app/components/pages/order-list/order-list.component.html
+++ b/src/app/components/pages/order-list/order-list.component.html
@@ -1,5 +1,5 @@
 <div class="order-list-container">
-  <h2>Mis Pedidos</h2>
+  <h2>Pedidos</h2>
 
   <div *ngIf="isLoading" class="loading-indicator">
     <p>Cargando pedidos...</p>
@@ -16,17 +16,23 @@
   </div>
 
   <div *ngIf="!isLoading && !errorMensaje && pedidos.length > 0" class="orders-grid">
-    <div *ngFor="let pedido of pedidos" class="order-card" (click)="verDetalle(pedido.Id)" role="button" tabindex="0" (keydown.enter)="verDetalle(pedido.Id)">
-      <div class="card-header">
+    <div *ngFor="let pedido of pedidos" class="order-row">
+      <div class="detail-column">
         <h3>Pedido #{{ pedido.Id }}</h3>
-      </div>
-      <div class="card-content">
         <p><strong>Fecha:</strong> {{ pedido.fecha | date:'dd/MM/yyyy' }}</p>
-        <p><strong>Estado:</strong> <span class="status" [ngClass]="'status-' + pedido.estado.toLowerCase().replace(' ', '-')">{{ pedido.estado }}</span></p>
+        <p><strong>Estado:</strong>
+          <span class="status" [ngClass]="'status-' + pedido.estado.toLowerCase().replace(' ', '-')">{{ pedido.estado }}</span>
+        </p>
         <p><strong>Total:</strong> {{ pedido.total | currency:'USD':'symbol':'1.2-2' }}</p>
+        <button class="btn btn-secondary" (click)="verDetalle(pedido.Id)">Ver Detalle</button>
       </div>
-      <div class="card-footer">
-        <button class="btn btn-secondary">Ver Detalle</button>
+      <div class="payment-column">
+        <label>Tipo de pago:</label>
+        <select [(ngModel)]="selectedPayment[pedido.Id]">
+          <option value="TRANSFERENCIA">Transferencia</option>
+          <option value="MERCADO_PAGO">Mercado Pago</option>
+        </select>
+        <button class="btn btn-primary" (click)="irAPago(pedido.Id)">Pagar</button>
       </div>
     </div>
   </div>

--- a/src/app/components/pages/order-list/order-list.component.scss
+++ b/src/app/components/pages/order-list/order-list.component.scss
@@ -45,37 +45,30 @@
   }
 
   .orders-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    display: flex;
+    flex-direction: column;
     gap: 1.5rem;
   }
 
-  .order-card {
+  .order-row {
+    display: grid;
+    grid-template-columns: 2fr 1fr;
+    gap: 1rem;
     background-color: var(--background-light);
     border-radius: var(--border-radius-lg);
     box-shadow: var(--shadow-sm);
     padding: 1.5rem;
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-    cursor: pointer;
+    align-items: center;
 
-    &:hover {
-      transform: translateY(-5px);
-      box-shadow: var(--shadow-md);
-    }
-
-    .card-header {
+    .detail-column {
       h3 {
         color: var(--primary-color);
         font-size: 1.5rem;
-        margin-bottom: 1rem;
-        border-bottom: 1px solid var(--grey-light);
-        padding-bottom: 0.5rem;
+        margin-bottom: 0.5rem;
       }
-    }
 
-    .card-content {
       p {
-        margin-bottom: 0.75rem;
+        margin-bottom: 0.5rem;
         font-size: 1rem;
         color: var(--text-color-light);
 
@@ -84,29 +77,8 @@
         }
       }
 
-      .status {
-        font-weight: bold;
-        padding: 0.25rem 0.5rem;
-        border-radius: var(--border-radius-sm);
-        color: #fff;
-        text-transform: uppercase;
-        font-size: 0.8rem;
-
-        // Colores de estado (ejemplos, ajusta según tus estados reales)
-        &.status-pago-pendiente { background-color: var(--warning-color); }
-        &.status-pagado { background-color: var(--success-color); }
-        &.status-enviado { background-color: var(--info-color); }
-        &.status-entregado { background-color: var(--primary-color); }
-        &.status-cancelado { background-color: var(--danger-color); }
-        // ...otros estados
-      }
-    }
-
-    .card-footer {
-      margin-top: 1rem;
-      text-align: right;
-
       .btn-secondary {
+        margin-top: 0.5rem;
         background-color: var(--accent-color);
         border-color: var(--accent-color);
         color: #fff;
@@ -114,6 +86,27 @@
         &:hover {
           background-color: var(--accent-dark);
           border-color: var(--accent-dark);
+        }
+      }
+    }
+
+    .payment-column {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+
+      select {
+        margin-bottom: 0.5rem;
+      }
+
+      .btn-primary {
+        background-color: var(--secondary-color);
+        border-color: var(--secondary-color);
+        color: #fff;
+
+        &:hover {
+          background-color: var(--secondary-dark);
+          border-color: var(--secondary-dark);
         }
       }
     }
@@ -130,16 +123,16 @@
   }
 
   .orders-grid {
-    grid-template-columns: 1fr; // Una columna en pantallas pequeñas
+    gap: 1rem;
   }
 
-  .order-card {
+  .order-row {
+    grid-template-columns: 1fr; // stack columns
     padding: 1rem;
-    .card-header h3 {
-      font-size: 1.3rem;
-    }
-    .card-content p {
-      font-size: 0.9rem;
+
+    .detail-column {
+      h3 { font-size: 1.3rem; }
+      p { font-size: 0.9rem; }
     }
   }
 }

--- a/src/app/components/pages/order-list/order-list.component.spec.ts
+++ b/src/app/components/pages/order-list/order-list.component.spec.ts
@@ -6,7 +6,8 @@ import { OrderListComponent } from './order-list.component';
 import { PedidoService } from '../../../services/pedido.service';
 import { Pedido } from '../../../model/pedido.model';
 import { Router } from '@angular/router';
-import { DatePipe, CurrencyPipe, CommonModule } from '@angular/common'; // Import CommonModule
+import { DatePipe, CurrencyPipe, CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
 
 describe('OrderListComponent', () => {
   let component: OrderListComponent;
@@ -27,7 +28,8 @@ describe('OrderListComponent', () => {
       declarations: [OrderListComponent], // Declare the component
       imports: [
         RouterTestingModule, // Provides basic router stubs
-        CommonModule // Import CommonModule for pipes like DatePipe, CurrencyPipe
+        CommonModule,
+        FormsModule
       ],
       providers: [
         { provide: PedidoService, useValue: mockPedidoService },
@@ -87,10 +89,10 @@ describe('OrderListComponent', () => {
   });
 
   describe('Template Rendering', () => {
-    it('should display "Mis Pedidos" title', () => {
+    it('should display "Pedidos" title', () => {
       fixture.detectChanges(); // Trigger change detection
       const titleElement = fixture.debugElement.query(By.css('h2'));
-      expect(titleElement.nativeElement.textContent).toContain('Mis Pedidos');
+      expect(titleElement.nativeElement.textContent).toContain('Pedidos');
     });
 
     it('should display "Cargando pedidos..." when isLoading is true', () => {
@@ -126,34 +128,34 @@ describe('OrderListComponent', () => {
       tick();
       fixture.detectChanges(); // Update view with fetched data
 
-      const orderCards = fixture.debugElement.queryAll(By.css('.order-card'));
-      expect(orderCards.length).toBe(2);
+      const orderRows = fixture.debugElement.queryAll(By.css('.order-row'));
+      expect(orderRows.length).toBe(2);
 
-      const firstCard = orderCards[0];
-      expect(firstCard.query(By.css('.card-header h3')).nativeElement.textContent).toContain(`Pedido #${mockPedidosData[0].id}`);
+      const firstRow = orderRows[0];
+      expect(firstRow.query(By.css('.detail-column h3')).nativeElement.textContent).toContain(`Pedido #${mockPedidosData[0].id}`);
       
       // Use DatePipe for formatting date as in component
       const datePipe = new DatePipe('en-US');
       const expectedDate = datePipe.transform(mockPedidosData[0].fecha, 'dd/MM/yyyy');
-      expect(firstCard.nativeElement.textContent).toContain(`Fecha: ${expectedDate}`);
-      
-      expect(firstCard.nativeElement.textContent).toContain(`Estado: ${mockPedidosData[0].estado}`);
+      expect(firstRow.nativeElement.textContent).toContain(`Fecha: ${expectedDate}`);
+
+      expect(firstRow.nativeElement.textContent).toContain(`Estado: ${mockPedidosData[0].estado}`);
       
       // Use CurrencyPipe for formatting total as in component
       const currencyPipe = new CurrencyPipe('en-US', 'USD'); // Adjust locale and currency code as needed
       const expectedTotal = currencyPipe.transform(mockPedidosData[0].total, 'USD', 'symbol', '1.2-2');
-      expect(firstCard.nativeElement.textContent).toContain(`Total: ${expectedTotal}`);
+      expect(firstRow.nativeElement.textContent).toContain(`Total: ${expectedTotal}`);
     }));
 
-    it('should call verDetalle when an order card is clicked', fakeAsync(() => {
+    it('should call verDetalle when detail button is clicked', fakeAsync(() => {
       spyOn(component, 'verDetalle');
       mockPedidoService.getOrders.and.returnValue(of(mockPedidosData));
       component.ngOnInit();
       tick();
       fixture.detectChanges();
 
-      const firstCard = fixture.debugElement.query(By.css('.order-card'));
-      firstCard.triggerEventHandler('click', null);
+      const detailBtn = fixture.debugElement.query(By.css('.detail-column .btn-secondary'));
+      detailBtn.triggerEventHandler('click', null);
       expect(component.verDetalle).toHaveBeenCalledWith(mockPedidosData[0].id);
     }));
   });

--- a/src/app/components/pages/order-list/order-list.component.ts
+++ b/src/app/components/pages/order-list/order-list.component.ts
@@ -1,13 +1,15 @@
 import { Component, OnInit } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 import { Pedido } from '../../../model/pedido.model';
 import { PedidoService } from '../../../services/pedido.service';
 import { CommonModule } from '@angular/common'; // Import CommonModule
+import { FormsModule } from '@angular/forms';
+import { AuthService } from '../../../services/auth.service';
 
 @Component({
   selector: 'app-order-list',
   standalone: true, // Ensure standalone is true
-  imports: [CommonModule], // Add CommonModule here
+  imports: [CommonModule, RouterModule, FormsModule],
   templateUrl: './order-list.component.html',
   styleUrls: ['./order-list.component.scss']
 })
@@ -15,13 +17,21 @@ export class OrderListComponent implements OnInit {
   pedidos: Pedido[] = [];
   isLoading: boolean = true;
   errorMensaje: string | null = null;
+  selectedPayment: { [id: number]: string } = {};
 
-  constructor(private pedidoService: PedidoService, private router: Router) {}
+  constructor(
+    private pedidoService: PedidoService,
+    private router: Router,
+    private authService: AuthService
+  ) {}
 
   ngOnInit(): void {
+    const usuario = this.authService.getUser();
     this.pedidoService.getOrders().subscribe({
       next: (data) => {
-        this.pedidos = data;
+        this.pedidos = usuario
+          ? data.filter(p => p.correoUsuario === usuario.email)
+          : [];
         this.isLoading = false;
       },
       error: (error) => {
@@ -34,5 +44,9 @@ export class OrderListComponent implements OnInit {
 
   verDetalle(pedidoId: number): void {
     this.router.navigate(['/pedidos', pedidoId]);
+  }
+
+  irAPago(pedidoId: number): void {
+    this.router.navigate(['/pago', pedidoId]);
   }
 }


### PR DESCRIPTION
## Summary
- show **Pedidos** link in navbar for logged-in users
- list user's orders in a 2‑column grid with payment option
- filter orders by logged user email
- update styles and specs for new layout

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68636857a6c48327a0ef8f50e0530bff