### PR TITLE
Add price to story detail view

### DIFF
--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -15,7 +15,10 @@
 
     <div class="detalle-info">
       <h1>{{ cuento?.titulo }}</h1>
-      <h3>Autor: {{ cuento?.autor }}</h3>
+      <div class="autor-precio">
+        <h3>Autor: {{ cuento?.autor }}</h3>
+        <span class="precio">S/ {{ cuento?.precio | number:'1.2-2' }}</span>
+      </div>
 
       <p class="descripcion">{{ cuento?.descripcionCorta }}</p>
 

--- a/src/app/components/detalle-cuento/detalle-cuento.component.scss
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.scss
@@ -49,6 +49,17 @@
   color: #8d6e63;
 }
 
+.autor-precio {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.autor-precio .precio {
+  font-weight: bold;
+  color: #8d6e63;
+}
+
 .descripcion {
   margin-bottom: 20px;
   font-size: 1rem;


### PR DESCRIPTION
## Summary
- show story price next to the author information
- style price with same color as author and align to the right

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68636c8a55b0832784a45f74c856f262