### PR TITLE
Improve UI for various components

### DIFF
--- a/src/app/components/cuento-card/cuento-card.component.html
+++ b/src/app/components/cuento-card/cuento-card.component.html
@@ -1,5 +1,9 @@
 <div class="cuento-card">
-  <img [src]="cuento.imagenUrl || 'assets/placeholder-cuento.jpg'" alt="{{cuento.titulo}}" (load)="imagenCargada()" (error)="cargarImagenPlaceholder($event)">
+  <span class="badge" *ngIf="isNuevo">Nuevo</span>
+  <div class="image-wrapper">
+    <img [src]="cuento.imagenUrl || 'assets/placeholder-cuento.jpg'" alt="{{cuento.titulo}}" loading="lazy" (load)="imagenCargada()" (error)="cargarImagenPlaceholder($event)">
+    <div class="image-placeholder" *ngIf="cargandoImagen"></div>
+  </div>
   <h3>{{ cuento.titulo }}</h3>
   <p>{{ cuento.autor }}</p>
   <p>S/ {{ cuento.precio | number:'1.2-2' }}</p>
@@ -12,5 +16,9 @@
       <button (click)="editarCuento()" class="admin-button editar">Editar</button>
       <button (click)="deshabilitarCuento()" class="admin-button deshabilitar">Deshabilitar</button>
     </ng-container>
+  </div>
+  <div class="share-buttons">
+    <button aria-label="Compartir por WhatsApp" (click)="compartir('whatsapp')">📱</button>
+    <button aria-label="Compartir por Instagram" (click)="compartir('instagram')">📸</button>
   </div>
 </div>

--- a/src/app/components/cuento-card/cuento-card.component.scss
+++ b/src/app/components/cuento-card/cuento-card.component.scss
@@ -1,9 +1,9 @@
+@import '../../../styles/variables';
+@import '../../../styles/mixins';
+
 .cuento-card {
-  background-color: #fff;
-  border-radius: 12px;
-  padding: 1rem;
+  @include card-style;
   text-align: center;
-  box-shadow: 0 2px 5px rgba(0,0,0,0.1);
   max-width: 300px;
   margin: auto;
   
@@ -11,6 +11,18 @@
     width: 100%;
     height: auto;
     border-radius: 10px;
+  }
+
+  .image-wrapper {
+    position: relative;
+  }
+
+  .image-placeholder {
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
+    background-size: 200% 100%;
+    animation: skeleton-loading 1.2s ease infinite;
   }
   .acciones {
     margin-top: 0.5rem;
@@ -68,7 +80,34 @@
       transform: scale(0.98);
     }
   }
+
+  .share-buttons {
+    display: none;
+    gap: 0.5rem;
+    justify-content: center;
+    margin-top: 0.5rem;
+
+    button {
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 1.2rem;
+      color: $primary;
+    }
+  }
+
+  .badge {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    background: $accent;
+    color: #fff;
+    padding: 2px 8px;
+    border-radius: $border-radius;
+    font-size: 0.75rem;
+  }
 }
+
 .cuento-card-imagen {
   display: flex;
   justify-content: center;
@@ -98,4 +137,13 @@
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
     cursor: pointer;
   }
+}
+
+:host(:hover) .share-buttons {
+  display: flex;
+}
+
+@keyframes skeleton-loading {
+  from { background-position: 200% 0; }
+  to { background-position: -200% 0; }
 }

--- a/src/app/components/cuento-card/cuento-card.component.ts
+++ b/src/app/components/cuento-card/cuento-card.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy, OnInit } from '@angular/core';
 import { Cuento } from '../../model/cuento.model'; // ajusta el path según tu estructura
 import { CartService } from '../../services/carrito.service';
 import { Router } from '@angular/router';
@@ -7,8 +7,9 @@ import { Router } from '@angular/router';
   selector: 'app-cuento-card',
   templateUrl: './cuento-card.component.html',
   styleUrls: ['./cuento-card.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class CuentoCardComponent {
+export class CuentoCardComponent implements OnInit {
   @Input() cuento!: Cuento;
   @Input() isAdmin: boolean = false; // Nueva entrada para modo admin
   @Output() agregar = new EventEmitter<Cuento>();
@@ -16,8 +17,17 @@ export class CuentoCardComponent {
   @Output() editar = new EventEmitter<Cuento>(); // Nuevo evento para editar
   @Output() deshabilitar = new EventEmitter<Cuento>(); // Nuevo evento para deshabilitar
   cargandoImagen: boolean = true;
+  isNuevo = false;
 
   constructor(private cartService: CartService, private router: Router) {}
+
+  ngOnInit(): void {
+    if (this.cuento?.fechaIngreso) {
+      const ingreso = new Date(this.cuento.fechaIngreso);
+      const diff = (Date.now() - ingreso.getTime()) / (1000 * 3600 * 24);
+      this.isNuevo = diff <= 30;
+    }
+  }
 
   verDetalle(): void {
     this.router.navigate(['/cuento', this.cuento.id]);
@@ -44,5 +54,14 @@ export class CuentoCardComponent {
 
   imagenCargada(): void {
     this.cargandoImagen = false;
+  }
+
+  compartir(tipo: 'whatsapp' | 'instagram'): void {
+    const url = encodeURIComponent(window.location.href + '/cuento/' + this.cuento.id);
+    if (tipo === 'whatsapp') {
+      window.open(`https://wa.me/?text=${url}`, '_blank');
+    } else {
+      window.open('https://www.instagram.com/', '_blank');
+    }
   }
 }

--- a/src/app/components/hero-banner/hero-banner.component.html
+++ b/src/app/components/hero-banner/hero-banner.component.html
@@ -1,6 +1,7 @@
-<section class="hero">
+<header class="hero" aria-labelledby="hero-title">
   <div class="hero-content">
-    <h1>Descubre un mundo mágico de cuentos</h1>
+    <h1 id="hero-title">Descubre un mundo mágico de cuentos</h1>
+    <p class="subtitle">{{ subtitle }}</p>
     <a routerLink="/cuentos" class="btn">Ver Cuentos</a>
   </div>
-</section>
+</header>

--- a/src/app/components/hero-banner/hero-banner.component.scss
+++ b/src/app/components/hero-banner/hero-banner.component.scss
@@ -1,20 +1,48 @@
+@import '../../../styles/variables';
+
 .hero {
-  background: linear-gradient(#FFEEAD, #FFAD60);
+  position: relative;
+  background: url('/assets/libros_killa.png') center/cover no-repeat;
   padding: 4rem 2rem;
   text-align: center;
-  color: #A66E38;
+  color: #fff;
+  filter: blur(0px);
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(0,0,0,0.4);
+    backdrop-filter: blur(3px);
+  }
 
   h1 {
     font-size: 2.5rem;
     margin-bottom: 1rem;
   }
 
+  .subtitle {
+    font-size: 1.2rem;
+    margin-bottom: 1rem;
+    opacity: 0.9;
+  }
+
   .btn {
     padding: 0.8rem 1.5rem;
-    background-color: #A66E38;
-    color: white;
+    background-color: #a66e38;
+    color: #fff;
     border: none;
     border-radius: 5px;
     text-decoration: none;
   }
+
+  .hero-content {
+    position: relative;
+    animation: fadeIn 1s ease;
+  }
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(20px); }
+  to { opacity: 1; transform: translateY(0); }
 }

--- a/src/app/components/hero-banner/hero-banner.component.ts
+++ b/src/app/components/hero-banner/hero-banner.component.ts
@@ -1,8 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'app-hero-banner',
   templateUrl: './hero-banner.component.html',
-  styleUrls: ['./hero-banner.component.scss']
+  styleUrls: ['./hero-banner.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class HeroBannerComponent {}
+export class HeroBannerComponent {
+  subtitle = 'Suscríbete a nuestra newsletter';
+}

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -1,9 +1,10 @@
-<nav class="navbar">
+<nav class="navbar" role="navigation" aria-label="Navegación principal">
   <a class="navbar-brand">
     <img src="assets/killa.bmp" alt="Cuentos de Killa" class="logo-img" />
     <span class="brand-text">Cuentos de Killa</span>
   </a>
-  <ul class="nav-links">
+  <button class="hamburger" aria-label="Menú" (click)="toggleMenu()">☰</button>
+  <ul class="nav-links" [class.open]="menuAbierto">
     <li><a routerLink="/home" routerLinkActive="active">Inicio</a></li>
     <li><a routerLink="/cuentos" routerLinkActive="active">Cuentos</a></li>
     <li>
@@ -22,9 +23,14 @@
     <li *ngIf="!user">
       <button class="btn-login" (click)="openLoginDialog()">Login</button>
     </li>
-    <li *ngIf="user?.nombre">
-      <span>👋 ¡Hola, {{ user?.nombre }}!</span>
-      <button class="btn-logout" (click)="logout()">Logout</button>
+    <li *ngIf="user?.nombre" class="avatar-wrapper" (click)="togglePerfil()">
+      <div class="avatar" [attr.title]="user?.nombre">{{ user?.nombre?.charAt(0) }}</div>
+      <ul class="perfil-menu" *ngIf="mostrarPerfil">
+        <li><a routerLink="/perfil">Mi perfil</a></li>
+        <li><a routerLink="/direcciones">Direcciones</a></li>
+        <li><a routerLink="/pagos">Historial de pagos</a></li>
+        <li><button (click)="logout()">Cerrar sesión</button></li>
+      </ul>
     </li>
   </ul>
 </nav>

--- a/src/app/components/navbar/navbar.component.scss
+++ b/src/app/components/navbar/navbar.component.scss
@@ -1,4 +1,6 @@
 
+@import '../../../styles/variables';
+
 /* Sidebar del carrito */
 .cart-sidebar {
   position: fixed;
@@ -25,6 +27,10 @@
   align-items: center;
   justify-content: space-between;
   color: white;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
 .navbar-brand {
@@ -69,6 +75,84 @@
         color: #ffeead; /* Amarillo claro al hover */
       }
     }
+  }
+}
+
+.hamburger {
+  display: none;
+  background: none;
+  border: none;
+  color: white;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.avatar-wrapper {
+  position: relative;
+
+  .perfil-menu {
+    display: none;
+    position: absolute;
+    right: 0;
+    top: 100%;
+    background: white;
+    color: #333;
+    list-style: none;
+    padding: 0.5rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+
+    li {
+      padding: 0.25rem 0.5rem;
+    }
+
+    a, button {
+      background: none;
+      border: none;
+      color: inherit;
+      text-decoration: none;
+      cursor: pointer;
+    }
+  }
+
+  .avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: #fff;
+    color: #a66e38;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    cursor: pointer;
+  }
+}
+
+.avatar-wrapper:hover .perfil-menu {
+  display: block;
+}
+
+@media (max-width: 768px) {
+  .nav-links {
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100%;
+    width: 200px;
+    background: #a66e38;
+    flex-direction: column;
+    padding-top: 4rem;
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+  }
+
+  .nav-links.open {
+    transform: translateX(0);
+  }
+
+  .hamburger {
+    display: block;
   }
 }
 

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -27,6 +27,8 @@ export class NavbarComponent implements OnInit {
   carritoAbierto = false; // 🔥
   cantidadItems: number = 0;
   user: User | null = null;
+  menuAbierto = false;
+  mostrarPerfil = false;
   constructor(
     private dialog: MatDialog,
     public CartService: CartService,
@@ -76,6 +78,14 @@ export class NavbarComponent implements OnInit {
   }
   cerrarCarrito() {
     this.carritoAbierto = false;
+  }
+
+  toggleMenu() {
+    this.menuAbierto = !this.menuAbierto;
+  }
+
+  togglePerfil() {
+    this.mostrarPerfil = !this.mostrarPerfil;
   }
   irACheckout() {
     const usuario = this.user;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -1,4 +1,6 @@
 /* You can add global styles to this file, and also import other style files */
+@import 'styles/variables';
+@import 'styles/mixins';
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,0 +1,6 @@
+@mixin card-style {
+  border-radius: $border-radius;
+  box-shadow: $shadow-sm;
+  background-color: #fff;
+  padding: 1rem;
+}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,0 +1,5 @@
+$primary: #a66e38;
+$secondary: #ffad60;
+$accent: #6db37f;
+$border-radius: 12px;
+$shadow-sm: 0 2px 4px rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary
- add SCSS variables and card-style mixin
- enhance cuento-card with badge, share buttons and skeleton image loader
- update hero banner with background image, subtitle and fade-in
- make navbar responsive with hamburger menu and avatar dropdown
- fix stylesheet import paths and template null check

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863db949bb0832796f0bed1ab5e1e80