### PR TITLE
Improve responsive navigation

### DIFF
--- a/src/app/components/cuentos-grid/cuentos-grid.component.scss
+++ b/src/app/components/cuentos-grid/cuentos-grid.component.scss
@@ -6,6 +6,13 @@
   background-color: #fffaf0;
 }
 
+@media (max-width: 600px) {
+  .grid-cuentos {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    padding: 1rem;
+  }
+}
+
 .cuento-card {
   background-color: #FFEEAD;
   border-radius: 16px;

--- a/src/app/components/hero-banner/hero-banner.component.scss
+++ b/src/app/components/hero-banner/hero-banner.component.scss
@@ -46,3 +46,17 @@
   from { opacity: 0; transform: translateY(20px); }
   to { opacity: 1; transform: translateY(0); }
 }
+
+@media (max-width: 600px) {
+  .hero {
+    padding: 2rem 1rem;
+
+    h1 {
+      font-size: 1.8rem;
+    }
+
+    .subtitle {
+      font-size: 1rem;
+    }
+  }
+}

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -5,8 +5,11 @@
   </a>
   <button class="hamburger" aria-label="Menú" (click)="toggleMenu()">☰</button>
   <ul class="nav-links" [class.open]="menuAbierto">
-    <li><a routerLink="/home" routerLinkActive="active">Inicio</a></li>
-    <li><a routerLink="/cuentos" routerLinkActive="active">Cuentos</a></li>
+    <li class="close-wrapper" *ngIf="menuAbierto">
+      <button class="close-menu" aria-label="Cerrar" (click)="closeMenu()">✖</button>
+    </li>
+    <li><a routerLink="/home" routerLinkActive="active" (click)="closeMenu()">Inicio</a></li>
+    <li><a routerLink="/cuentos" routerLinkActive="active" (click)="closeMenu()">Cuentos</a></li>
     <li>
       <a class="carrito-enlace" (click)="abrirCarrito()" style="cursor: pointer;" >
         🛒
@@ -15,10 +18,10 @@
       </a>
     </li>
     <li *ngIf="user?.role === 'ADMIN'">
-      <a routerLink="/admin/dashboard" routerLinkActive="active">Admin</a>
+      <a routerLink="/admin/dashboard" routerLinkActive="active" (click)="closeMenu()">Admin</a>
     </li>
     <li *ngIf="user">
-      <a routerLink="/pedidos" routerLinkActive="active">Pedidos</a>
+      <a routerLink="/pedidos" routerLinkActive="active" (click)="closeMenu()">Pedidos</a>
     </li>
     <li *ngIf="!user">
       <button class="btn-login" (click)="openLoginDialog()">Login</button>
@@ -26,9 +29,9 @@
     <li *ngIf="user?.nombre" class="avatar-wrapper" (click)="togglePerfil()">
       <div class="avatar" [attr.title]="user?.nombre">{{ user?.nombre?.charAt(0) }}</div>
       <ul class="perfil-menu" *ngIf="mostrarPerfil">
-        <li><a routerLink="/perfil">Mi perfil</a></li>
-        <li><a routerLink="/direcciones">Direcciones</a></li>
-        <li><a routerLink="/pagos">Historial de pagos</a></li>
+        <li><a routerLink="/perfil" (click)="closeMenu()">Mi perfil</a></li>
+        <li><a routerLink="/direcciones" (click)="closeMenu()">Direcciones</a></li>
+        <li><a routerLink="/pagos" (click)="closeMenu()">Historial de pagos</a></li>
         <li><button (click)="logout()">Cerrar sesión</button></li>
       </ul>
     </li>
@@ -60,3 +63,4 @@
 </div>
 <!-- Overlay -->
 <div class="overlay" [class.show]="carritoAbierto" (click)="cerrarCarrito()"></div>
+<div class="menu-overlay" [class.show]="menuAbierto" (click)="closeMenu()"></div>

--- a/src/app/components/navbar/navbar.component.scss
+++ b/src/app/components/navbar/navbar.component.scss
@@ -78,6 +78,18 @@
   }
 }
 
+.close-menu {
+  background: none;
+  border: none;
+  color: white;
+  font-size: 1.5rem;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  cursor: pointer;
+  display: none;
+}
+
 .hamburger {
   display: none;
   background: none;
@@ -149,6 +161,10 @@
 
   .nav-links.open {
     transform: translateX(0);
+  }
+
+  .close-menu {
+    display: block;
   }
 
   .hamburger {
@@ -273,6 +289,24 @@
   pointer-events: none;
   transition: opacity 0.3s ease;
   z-index: 1000;
+
+  &.show {
+    opacity: 1;
+    pointer-events: all;
+  }
+}
+
+.menu-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  background: rgba(0,0,0,0.5);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  z-index: 999;
 
   &.show {
     opacity: 1;

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -84,6 +84,10 @@ export class NavbarComponent implements OnInit {
     this.menuAbierto = !this.menuAbierto;
   }
 
+  closeMenu() {
+    this.menuAbierto = false;
+  }
+
   togglePerfil() {
     this.mostrarPerfil = !this.mostrarPerfil;
   }

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.scss
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.scss
@@ -1,10 +1,11 @@
 // admin-dashboard.component.scss
+
 .dashboard-container {
     padding: 2rem;
     background-color: #fffaf5;
   
-    h2 {
-      font-size: 24px;
+  h2 {
+    font-size: 24px;
       font-weight: bold;
       color: #3c2f2f;
       margin-bottom: 1.5rem;
@@ -36,6 +37,20 @@
         font-weight: bold;
         color: #a66e38;
       }
+    }
+  }
+
+  @media (max-width: 600px) {
+    .cards {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    h2 {
+      font-size: 20px;
+    }
+    .card p {
+      font-size: 20px;
     }
   }
   

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.html
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.html
@@ -1,16 +1,18 @@
-<div class="admin-layout">
-    <aside class="sidebar">
-      <h3>Cuentos de Killa</h3>
-      <nav>
-        <a routerLink="/admin/dashboard" routerLinkActive="active">Dashboard</a>
-        <a routerLink="/admin/cuentos" routerLinkActive="active">Cuentos</a>
-        <a routerLink="/admin/pedidos" routerLinkActive="active">Pedidos</a>
-        <a routerLink="/admin/usuarios" routerLinkActive="active">Usuarios</a>
-      </nav>
-    </aside>
-  
-    <main class="content">
-      <router-outlet></router-outlet>
-    </main>
-  </div>
+<div class="admin-layout" [class.menu-open]="menuAbierto">
+  <button class="menu-toggle" (click)="toggleMenu()">☰</button>
+  <aside class="sidebar" [class.open]="menuAbierto">
+    <h3>Cuentos de Killa</h3>
+    <nav>
+      <a routerLink="/admin/dashboard" routerLinkActive="active" (click)="toggleMenu(false)">Dashboard</a>
+      <a routerLink="/admin/cuentos" routerLinkActive="active" (click)="toggleMenu(false)">Cuentos</a>
+      <a routerLink="/admin/pedidos" routerLinkActive="active" (click)="toggleMenu(false)">Pedidos</a>
+      <a routerLink="/admin/usuarios" routerLinkActive="active" (click)="toggleMenu(false)">Usuarios</a>
+    </nav>
+  </aside>
+
+  <main class="content">
+    <router-outlet></router-outlet>
+  </main>
+  <div class="overlay" [class.show]="menuAbierto" (click)="toggleMenu(false)"></div>
+</div>
   

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
@@ -1,36 +1,93 @@
+
 .admin-layout {
-    display: flex;
-    height: 100vh;
-  
-    .sidebar {
-      width: 240px;
-      background-color: #a66e38;
-      color: white;
-      padding: 2rem 1rem;
-  
-      h3 {
-        font-size: 1.5rem;
-        margin-bottom: 2rem;
-      }
-  
-      nav a {
-        display: block;
-        color: white;
-        text-decoration: none;
-        margin: 1rem 0;
-        font-weight: 500;
-  
-        &.active {
-          text-decoration: underline;
-        }
-      }
+  display: flex;
+  height: 100vh;
+
+  .menu-toggle {
+    display: none;
+    position: fixed;
+    top: 1rem;
+    left: 1rem;
+    background: #a66e38;
+    color: #fff;
+    border: none;
+    padding: 0.5rem;
+    font-size: 1.5rem;
+    border-radius: 4px;
+    z-index: 1100;
+    cursor: pointer;
+  }
+
+  .sidebar {
+    width: 240px;
+    background-color: #a66e38;
+    color: white;
+    padding: 2rem 1rem;
+
+    h3 {
+      font-size: 1.5rem;
+      margin-bottom: 2rem;
     }
-  
-    .content {
-      flex: 1;
-      padding: 2rem;
-      background-color: #fffaf5;
-      overflow-y: auto;
+
+    nav a {
+      display: block;
+      color: white;
+      text-decoration: none;
+      margin: 1rem 0;
+      font-weight: 500;
+
+      &.active {
+        text-decoration: underline;
+      }
     }
   }
+
+  .content {
+    flex: 1;
+    padding: 2rem;
+    background-color: #fffaf5;
+    overflow-y: auto;
+  }
+
+  .overlay {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .admin-layout {
+    .menu-toggle {
+      display: block;
+    }
+
+    .sidebar {
+      position: fixed;
+      left: -240px;
+      top: 0;
+      height: 100%;
+      transition: left 0.3s;
+      z-index: 1000;
+    }
+
+    &.menu-open {
+      .sidebar {
+        left: 0;
+      }
+
+      .overlay {
+        display: block;
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 900;
+      }
+    }
+    .content {
+      padding: 1rem;
+    }
+  }
+}
   

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
@@ -9,5 +9,9 @@ import { RouterModule } from '@angular/router';
   styleUrls: ['./admin-layout.component.scss']
 })
 export class AdminLayoutComponent {
+  menuAbierto = false;
 
+  toggleMenu(force?: boolean) {
+    this.menuAbierto = force !== undefined ? force : !this.menuAbierto;
+  }
 }

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.scss
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.scss
@@ -16,3 +16,11 @@ th, td {
 th {
   background-color: #f2f2f2;
 }
+
+@media (max-width: 600px) {
+  table {
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+}


### PR DESCRIPTION
## Summary
- add mobile close button for the navbar and overlay
- close menu after clicking links
- tweak hero banner and grid for small screens
- make admin layout responsive with toggleable sidebar

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863f1b92b60832798d88c47e4c5978a