### PR TITLE
Add cuentos listing page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -20,12 +20,12 @@ export const routes: Routes = [
         loadChildren: () =>
           import('./components/pages/Home/home.module').then((m) => m.HomeModule),
       } 
-      // {
-      //   path: 'cuentos',
-      //   loadChildren: () =>
-      //     import('./components/pages/Cuentos/cuentos.module').then(m => m.CuentosModule),
-      // }
-      , {
+      {
+        path: 'cuentos',
+        loadChildren: () =>
+          import('./components/pages/cuentos/cuentos.module').then(m => m.CuentosModule),
+      },
+      {
         path: 'cuento/:id',
         loadChildren: () =>
           import('./components/detalle-cuento/detalle-cuento.module').then(m => m.DetalleCuentoModule),

--- a/src/app/components/pages/cuentos/cuentos.component.html
+++ b/src/app/components/pages/cuentos/cuentos.component.html
@@ -1,0 +1,18 @@
+<div class="cuentos-container">
+  <h2>Últimos cuentos</h2>
+  <div class="filters">
+    <input type="text" placeholder="Buscar por título o autor" [(ngModel)]="searchTerm" />
+    <select [(ngModel)]="sortOption">
+      <option value="fecha">Fecha de registro</option>
+      <option value="alfabetico">Alfabético</option>
+      <option value="precio">Precio</option>
+    </select>
+  </div>
+  <div class="grid-cuentos">
+    <app-cuento-card
+      *ngFor="let cuento of filteredCuentos"
+      [cuento]="cuento"
+      (agregar)="agregarAlCarrito($event)"
+    ></app-cuento-card>
+  </div>
+</div>

--- a/src/app/components/pages/cuentos/cuentos.component.scss
+++ b/src/app/components/pages/cuentos/cuentos.component.scss
@@ -1,0 +1,31 @@
+.cuentos-container {
+  padding: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.filters {
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  margin-bottom: 1rem;
+
+  input,
+  select {
+    padding: 0.5rem;
+    border-radius: 4px;
+    border: 1px solid #ccc;
+  }
+}
+
+.grid-cuentos {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+@media (max-width: 600px) {
+  .grid-cuentos {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  }
+}

--- a/src/app/components/pages/cuentos/cuentos.component.ts
+++ b/src/app/components/pages/cuentos/cuentos.component.ts
@@ -1,0 +1,56 @@
+import { Component, OnInit } from '@angular/core';
+import { Cuento } from '../../../model/cuento.model';
+import { CuentoService } from '../../../services/cuento.service';
+import { CartService } from '../../../services/carrito.service';
+import { Router } from '@angular/router';
+
+@Component({
+  selector: 'app-cuentos-page',
+  templateUrl: './cuentos.component.html',
+  styleUrls: ['./cuentos.component.scss']
+})
+export class CuentosComponent implements OnInit {
+  cuentos: Cuento[] = [];
+  searchTerm = '';
+  sortOption: 'fecha' | 'alfabetico' | 'precio' = 'fecha';
+
+  constructor(
+    private cuentoService: CuentoService,
+    private cartService: CartService,
+    private router: Router
+  ) {}
+
+  ngOnInit(): void {
+    this.cuentoService.obtenerCuentos().subscribe(data => {
+      this.cuentos = data
+        .sort((a, b) => new Date(b.fechaIngreso).getTime() - new Date(a.fechaIngreso).getTime())
+        .slice(0, 20);
+    });
+  }
+
+  get filteredCuentos(): Cuento[] {
+    let filtered = this.cuentos.filter(c =>
+      c.titulo.toLowerCase().includes(this.searchTerm.toLowerCase()) ||
+      c.autor.toLowerCase().includes(this.searchTerm.toLowerCase())
+    );
+    switch (this.sortOption) {
+      case 'alfabetico':
+        filtered = filtered.sort((a, b) => a.titulo.localeCompare(b.titulo));
+        break;
+      case 'precio':
+        filtered = filtered.sort((a, b) => a.precio - b.precio);
+        break;
+      default:
+        filtered = filtered.sort((a, b) => new Date(b.fechaIngreso).getTime() - new Date(a.fechaIngreso).getTime());
+    }
+    return filtered;
+  }
+
+  agregarAlCarrito(cuento: Cuento): void {
+    this.cartService.addItem(cuento);
+  }
+
+  verDetalle(id: number): void {
+    this.router.navigate(['/cuento', id]);
+  }
+}

--- a/src/app/components/pages/cuentos/cuentos.module.ts
+++ b/src/app/components/pages/cuentos/cuentos.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule, Routes } from '@angular/router';
+import { FormsModule } from '@angular/forms';
+import { CuentosComponent } from './cuentos.component';
+import { CuentoCardComponent } from '../../cuento-card/cuento-card.component';
+
+const routes: Routes = [
+  { path: '', component: CuentosComponent }
+];
+
+@NgModule({
+  declarations: [CuentosComponent],
+  imports: [CommonModule, FormsModule, RouterModule.forChild(routes), CuentoCardComponent],
+})
+export class CuentosModule {}


### PR DESCRIPTION
## Summary
- add CuentosModule with page to list last 20 cuentos
- enable filtering and sorting of cuentos
- link new module in router

## Testing
- `npm test` *(fails: ng not found / network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686406ea355c8327a5cf96dc651bd5d4