### PR TITLE
Add admin error messages

### DIFF
--- a/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.html
+++ b/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.html
@@ -7,7 +7,9 @@
     </button>
   </div>
 
-  <div class="grid-cuentos">
+  <div *ngIf="isLoading">Cargando cuentos...</div>
+  <div class="error-mensaje" *ngIf="errorMensaje">{{ errorMensaje }}</div>
+  <div class="grid-cuentos" *ngIf="!isLoading && !errorMensaje">
     <app-cuento-card
       *ngFor="let cuento of cuentos"
       [cuento]="cuento"

--- a/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.ts
+++ b/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.ts
@@ -13,6 +13,8 @@ export class AdminCuentosComponent implements OnInit {
   // @Input() cuento!: Cuento; // This Input seems unused here, more for a detail/card component
   cuentos: Cuento[] = [];
   cuentoParaDeshabilitar: Cuento | null = null;
+  isLoading = true;
+  errorMensaje: string | null = null;
   // cargandoImagen: boolean = true; // This logic is now in CuentoCardComponent
 
   constructor(
@@ -22,8 +24,16 @@ export class AdminCuentosComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    this.cuentoService.obtenerCuentos().subscribe(data => {
-      this.cuentos = data;
+    this.cuentoService.obtenerCuentos().subscribe({
+      next: data => {
+        this.cuentos = data;
+        this.isLoading = false;
+      },
+      error: err => {
+        console.error('Error al cargar cuentos:', err);
+        this.errorMensaje = 'No se pudieron cargar los cuentos';
+        this.isLoading = false;
+      }
     });
   }
 
@@ -62,11 +72,18 @@ export class AdminCuentosComponent implements OnInit {
   confirmarDeshabilitar(): void {
     if (!this.cuentoParaDeshabilitar) return;
     const id = this.cuentoParaDeshabilitar.id;
-    this.cuentoService.deshabilitarCuento(id, false).subscribe(() => {
-      this.cuentos = this.cuentos.map(c =>
-        c.id === id ? { ...c, habilitado: false } : c
-      );
-      this.cuentoParaDeshabilitar = null;
+    this.cuentoService.deshabilitarCuento(id, false).subscribe({
+      next: () => {
+        this.cuentos = this.cuentos.map(c =>
+          c.id === id ? { ...c, habilitado: false } : c
+        );
+        this.cuentoParaDeshabilitar = null;
+      },
+      error: err => {
+        console.error('Error al cambiar el estado del cuento:', err);
+        this.errorMensaje = 'No se pudo actualizar el estado del cuento';
+        this.cuentoParaDeshabilitar = null;
+      }
     });
   }
 

--- a/src/app/components/pages/admin/cuento-form/cuento-form.component.ts
+++ b/src/app/components/pages/admin/cuento-form/cuento-form.component.ts
@@ -16,6 +16,7 @@ export class CuentoFormComponent implements OnInit {
   imagePreview: string | null = null;
   selectedFile?: File;
   imagenBase64: string | null = null;
+  errorMensaje: string | null = null;
 
   constructor(
     private fb: FormBuilder,
@@ -42,20 +43,26 @@ export class CuentoFormComponent implements OnInit {
     if (idParam) {
       this.isEditMode = true;
       this.cuentoId = +idParam;
-      this.cuentoService.getCuentoById(this.cuentoId).subscribe(c => {
-        this.cuentoForm.patchValue({
-          titulo: c.titulo,
-          autor: c.autor,
-          descripcionCorta: c.descripcionCorta,
-          editorial: c.editorial,
-          tipoEdicion: c.tipoEdicion,
-          nroPaginas: c.nroPaginas,
-          fechaPublicacion: c.fechaPublicacion,
-          edadRecomendada: c.edadRecomendada,
-          stock: c.stock,
-          precio: c.precio
-        });
-        this.imagePreview = c.imagenUrl;
+      this.cuentoService.getCuentoById(this.cuentoId).subscribe({
+        next: c => {
+          this.cuentoForm.patchValue({
+            titulo: c.titulo,
+            autor: c.autor,
+            descripcionCorta: c.descripcionCorta,
+            editorial: c.editorial,
+            tipoEdicion: c.tipoEdicion,
+            nroPaginas: c.nroPaginas,
+            fechaPublicacion: c.fechaPublicacion,
+            edadRecomendada: c.edadRecomendada,
+            stock: c.stock,
+            precio: c.precio
+          });
+          this.imagePreview = c.imagenUrl;
+        },
+        error: err => {
+          console.error('Error al obtener el cuento:', err);
+          this.errorMensaje = 'No se pudo cargar la información del cuento';
+        }
       });
     }
   }
@@ -86,7 +93,13 @@ export class CuentoFormComponent implements OnInit {
       ? this.cuentoService.actualizarCuento(this.cuentoId, cuentoData)
       : this.cuentoService.crearCuento(cuentoData);
 
-    request$.subscribe(() => this.router.navigate(['/admin/cuentos']));
+    request$.subscribe({
+      next: () => this.router.navigate(['/admin/cuentos']),
+      error: err => {
+        console.error('Error al guardar el cuento:', err);
+        this.errorMensaje = 'Ocurrió un error al guardar el cuento';
+      }
+    });
   }
 
   cancelar(): void {

--- a/src/app/components/pages/admin/cuento-form/cuento-form.html
+++ b/src/app/components/pages/admin/cuento-form/cuento-form.html
@@ -50,6 +50,8 @@
       <img *ngIf="imagePreview" [src]="imagePreview" class="preview" />
     </div>
 
+    <div class="error-mensaje" *ngIf="errorMensaje">{{ errorMensaje }}</div>
+
     <div class="acciones">
       <button type="submit" class="aceptar">{{ isEditMode ? 'Actualizar' : 'Crear' }}</button>
       <button type="button" class="cancelar" (click)="cancelar()">Cancelar</button>


### PR DESCRIPTION
## Summary
- display loading and error states on admin cuentos list
- handle errors when disabling a cuento
- show messages when failing to fetch or save in the cuento form

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686407632cbc8327a1f761182bd0f7f4