### PR TITLE
Fix admin menu overlay and router links

### DIFF
--- a/src/app/components/navbar/navbar.component.scss
+++ b/src/app/components/navbar/navbar.component.scss
@@ -12,7 +12,7 @@
   box-shadow: -2px 0 5px rgba(0, 0, 0, 0.3);
   transform: translateX(100%);
   transition: transform 0.3s ease-in-out;
-  z-index: 1000;
+  z-index: 1000; /* Ensure navbar stays above admin sidebar */
   padding: 1rem;
 }
 .cart-sidebar.open {
@@ -29,7 +29,7 @@
   color: white;
   position: sticky;
   top: 0;
-  z-index: 1000;
+  z-index: 1200; /* Ensure navbar stays above admin sidebar */
   box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
@@ -288,7 +288,7 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s ease;
-  z-index: 1000;
+  z-index: 1200; /* Ensure navbar stays above admin sidebar */
 
   &.show {
     opacity: 1;

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { LoginComponent } from '../pages/login/login.component';
 import { MatDialog } from '@angular/material/dialog';
 import { CartService } from '../../services/carrito.service';
-import { Router } from '@angular/router';
+import { Router, RouterModule } from '@angular/router';
 
 import { CartModalComponent } from '../cart-modal/cart-modal.component';
 import { AuthService } from '../../services/auth.service';
@@ -20,6 +20,7 @@ import { User } from '../../model/user.model';
   styleUrls: ['./navbar.component.scss'],
   imports: [
     CommonModule, // 🔥 necesario para *ngIf, *ngFor
+    RouterModule, // habilita routerLink en la plantilla
     // otros imports que tengas como MatDialogModule, etc.
   ]
 })

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
@@ -60,11 +60,13 @@
       display: block;
     }
 
+    $nav-height: 60px; // altura aproximada del navbar
+
     .sidebar {
       position: fixed;
       left: -240px;
-      top: 0;
-      height: 100%;
+      top: $nav-height;
+      height: calc(100% - $nav-height);
       transition: left 0.3s;
       z-index: 1000;
     }
@@ -77,10 +79,10 @@
       .overlay {
         display: block;
         position: fixed;
-        top: 0;
+        top: $nav-height;
         left: 0;
         width: 100%;
-        height: 100%;
+        height: calc(100% - $nav-height);
         background: rgba(0, 0, 0, 0.5);
         z-index: 900;
       }


### PR DESCRIPTION
## Summary
- keep navbar above admin sidebar and overlay
- prevent admin sidebar from covering logo by offsetting it below navbar
- make routerLink work in navbar

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686412c8a254832796976481449a7706