### PR TITLE
Improve order list layout and filtering

### DIFF
--- a/src/app/components/pages/order-list/order-list.component.html
+++ b/src/app/components/pages/order-list/order-list.component.html
@@ -16,19 +16,17 @@
     <button routerLink="/cuentos" class="btn btn-primary">Explorar Cuentos</button>
   </div>
 
-  <div *ngIf="!isLoading && !errorMensaje && pedidos.length > 0" class="filters">
+  <div *ngIf="!isLoading && !errorMensaje && pedidos.length > 0" class="filter-bar">
     <input type="text" placeholder="Buscar n\u00BA pedido" [(ngModel)]="searchTerm" />
     <select [(ngModel)]="estadoFilter">
       <option value="">Todos</option>
-      <option value="ENTREGADO">Entregado</option>
-      <option value="ENVIADO">Enviado</option>
-      <option value="PAGADO">Pagado</option>
-      <option value="PAGO_PENDIENTE">Pago Pendiente</option>
+      <option *ngFor="let est of estadosUnicos" [value]="est">{{ est }}</option>
     </select>
+    <button type="button" class="btn btn-outline export-btn" (click)="exportCSV()">Exportar CSV</button>
   </div>
 
   <div *ngIf="!isLoading && !errorMensaje && filteredPedidos.length > 0" class="orders-grid" role="region">
-    <div *ngFor="let pedido of paginatedPedidos" class="order-row order-card" [@fadeSlideIn]>
+    <div *ngFor="let pedido of paginatedPedidos; trackBy: trackByPedidoId" class="order-row order-card" role="button" tabindex="0" [attr.aria-label]="'Detalles del pedido número ' + pedido.Id" [@fadeSlideIn]>
       <div class="detail-column">
         <h3><span class="material-icons book-icon">menu_book</span>Pedido #{{ pedido.Id }}</h3>
         <p><strong>Fecha:</strong> {{ pedido.fecha | date:'dd/MM/yyyy' }}</p>
@@ -36,7 +34,7 @@
           <span class="status" [ngClass]="'status-' + pedido.estado.toLowerCase().replace(' ', '-')">{{ pedido.estado }}</span>
         </p>
         <p><strong>Total:</strong> {{ pedido.total | currency:'USD':'symbol':'1.2-2' }}</p>
-        <button class="btn btn-secondary" (click)="verDetalle(pedido.Id)" [attr.aria-label]="'Ver detalle del pedido ' + pedido.Id">Ver Detalle</button>
+        <button class="btn btn-primary ver-detalle" (click)="verDetalle(pedido.Id)" [attr.aria-label]="'Ver detalle del pedido ' + pedido.Id">Ver Detalle</button>
         <button class="btn btn-outline" (click)="descargarPDF(pedido.Id)">Descargar PDF</button>
         <button *ngIf="pedido.estado === 'ENTREGADO'" class="btn btn-outline" (click)="dejarResena(pedido.Id)">Valorar</button>
       </div>

--- a/src/app/components/pages/order-list/order-list.component.scss
+++ b/src/app/components/pages/order-list/order-list.component.scss
@@ -44,8 +44,9 @@
     }
   }
 
-  .filters {
+  .filter-bar {
     display: flex;
+    flex-wrap: wrap;
     gap: 1rem;
     justify-content: center;
     margin-bottom: 1rem;
@@ -53,6 +54,9 @@
       padding: 0.5rem;
       border-radius: 4px;
       border: 1px solid var(--grey-light);
+    }
+    .export-btn {
+      padding: 0.5rem 1rem;
     }
   }
 
@@ -62,7 +66,8 @@
     grid-template-columns: 1fr;
   }
 
-  .order-row {
+  .order-row,
+  .order-card {
     display: grid;
     grid-template-columns: 2fr 1fr;
     gap: 1rem;
@@ -73,11 +78,17 @@
     align-items: center;
     border: 1px solid transparent;
     transition: box-shadow .3s, border-color .3s, transform .3s;
+    position: relative;
 
-    &:hover {
+    &:focus {
+      outline: 2px solid var(--accent-color);
+    }
+
+    &:hover,
+    &:focus {
       box-shadow: var(--shadow-md);
       border-color: var(--primary-color);
-      transform: translateY(-2px);
+      transform: translateY(-4px);
     }
 
     .detail-column {
@@ -97,8 +108,10 @@
         }
       }
 
-      .btn-secondary {
-        margin-top: 0.5rem;
+      .ver-detalle {
+        position: absolute;
+        bottom: 1rem;
+        right: 1rem;
         background-color: var(--accent-color);
         border-color: var(--accent-color);
         color: #fff;

--- a/src/app/components/pages/order-list/order-list.component.ts
+++ b/src/app/components/pages/order-list/order-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { Pedido } from '../../../model/pedido.model';
 import { PedidoService } from '../../../services/pedido.service';
@@ -13,6 +13,7 @@ import { trigger, transition, style, animate } from '@angular/animations';
   imports: [CommonModule, RouterModule, FormsModule],
   templateUrl: './order-list.component.html',
   styleUrls: ['./order-list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   animations: [
     trigger('fadeSlideIn', [
       transition(':enter', [
@@ -29,6 +30,7 @@ export class OrderListComponent implements OnInit {
   selectedPayment: { [id: number]: string } = {};
   searchTerm: string = '';
   estadoFilter: string = '';
+  estadosUnicos: string[] = [];
   currentPage: number = 1;
   itemsPerPage: number = 5;
 
@@ -45,6 +47,7 @@ export class OrderListComponent implements OnInit {
         this.pedidos = usuario
           ? data.filter(p => p.correoUsuario === usuario.email)
           : [];
+        this.estadosUnicos = Array.from(new Set(this.pedidos.map(p => p.estado)));
         this.isLoading = false;
       },
       error: (error) => {
@@ -104,5 +107,22 @@ export class OrderListComponent implements OnInit {
 
   dejarResena(pedidoId: number): void {
     this.router.navigate(['/reseña', pedidoId]);
+  }
+
+  trackByPedidoId(index: number, pedido: Pedido) {
+    return pedido.Id;
+  }
+
+  exportCSV(): void {
+    const headers = ['Id', 'fecha', 'estado', 'total'];
+    const filas = this.filteredPedidos.map(p => [p.Id, p.fecha, p.estado, p.total]);
+    const contenido = [headers.join(','), ...filas.map(f => f.join(','))].join('\n');
+    const blob = new Blob([contenido], { type: 'text/csv;charset=utf-8;' });
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'pedidos.csv';
+    a.click();
+    window.URL.revokeObjectURL(url);
   }
 }


### PR DESCRIPTION
## Summary
- add `ChangeDetectionStrategy.OnPush` and trackBy for order list
- capture unique order states to build dynamic filter options
- add CSV export button and restructure filter bar
- enhance order card styling and accessibility

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68641c501db88327a5ca7f4834aff634