### PR TITLE
Update cuento card info and stock logic

### DIFF
--- a/src/app/components/cuento-card/cuento-card.component.html
+++ b/src/app/components/cuento-card/cuento-card.component.html
@@ -4,17 +4,17 @@
     <img [src]="cuento.imagenUrl || 'assets/placeholder-cuento.jpg'" alt="{{cuento.titulo}}" loading="lazy" (load)="imagenCargada()" (error)="cargarImagenPlaceholder($event)">
     <div class="image-placeholder" *ngIf="cargandoImagen"></div>
   </div>
-  <h3>{{ cuento.titulo }}</h3>
-  <p>{{ cuento.autor }}</p>
-  <p>S/ {{ cuento.precio | number:'1.2-2' }}</p>
-  <p>Agregado: {{ cuento.fechaIngreso | date:'shortDate' }}</p>
+  <h3>Titulo: {{ cuento.titulo }}</h3>
+  <p>Autor: {{ cuento.autor }}</p>
+  <p>Precio: S/ {{ cuento.precio | number:'1.2-2' }}</p>
+  <p>Agregado el {{ cuento.fechaIngreso | date:'MM-yyyy' }}</p>
 
   <div class="acciones">
     <button (click)="verDetalle()">Ver detalle</button>
-    <button *ngIf="!isAdmin" (click)="agregarAlCarrito()">Agregar al carrito</button>
+    <button *ngIf="!isAdmin && cuento.habilitado" (click)="agregarAlCarrito()">Agregar al carrito</button>
     <ng-container *ngIf="isAdmin">
       <button (click)="editarCuento()" class="admin-button editar">Editar</button>
-      <button (click)="deshabilitarCuento()" class="admin-button deshabilitar">Deshabilitar</button>
+      <button (click)="deshabilitarCuento()" class="admin-button deshabilitar">{{ cuento.habilitado ? 'Deshabilitar' : 'Habilitar' }}</button>
     </ng-container>
   </div>
   <div class="share-buttons">

--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -19,6 +19,7 @@
         <h3>Autor: {{ cuento?.autor }}</h3>
         <span class="precio">S/ {{ cuento?.precio | number:'1.2-2' }}</span>
       </div>
+      <p class="stock">Stock: {{ cuento?.habilitado ? cuento?.stock : 'Sin stock' }}</p>
 
       <p class="descripcion">{{ cuento?.descripcionCorta }}</p>
 
@@ -31,7 +32,7 @@
       </div>
 
       <div class="acciones">
-        <button class="boton-dorado" (click)="agregarAlCarrito(); $event.stopPropagation()">
+        <button class="boton-dorado" (click)="agregarAlCarrito(); $event.stopPropagation()" [disabled]="!cuento?.habilitado">
           Agregar al carrito
         </button>
         <button class="boton-volver" (click)="volver(); $event.stopPropagation()">Volver</button>

--- a/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.ts
+++ b/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.ts
@@ -72,10 +72,11 @@ export class AdminCuentosComponent implements OnInit {
   confirmarDeshabilitar(): void {
     if (!this.cuentoParaDeshabilitar) return;
     const id = this.cuentoParaDeshabilitar.id;
-    this.cuentoService.deshabilitarCuento(id, false).subscribe({
+    const nuevoEstado = !this.cuentoParaDeshabilitar.habilitado;
+    this.cuentoService.deshabilitarCuento(id, nuevoEstado).subscribe({
       next: () => {
         this.cuentos = this.cuentos.map(c =>
-          c.id === id ? { ...c, habilitado: false } : c
+          c.id === id ? { ...c, habilitado: nuevoEstado } : c
         );
         this.cuentoParaDeshabilitar = null;
       },


### PR DESCRIPTION
## Summary
- show labels for title, author, price and date on cuento card
- hide "Agregar al carrito" button when cuento is disabled
- toggle enable/disable button text in admin cuentos page and update toggle logic
- display stock status and disable cart button on detail view

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686439c5d2388327bfa0743e4e1be5ad