### PR TITLE
Improve mobile admin navigation

### DIFF
--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.html
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.html
@@ -1,18 +1,32 @@
 <div class="admin-layout" [class.menu-open]="menuAbierto">
-  <button class="menu-toggle" (click)="toggleMenu()">☰</button>
-  <aside class="sidebar" [class.open]="menuAbierto">
-    <h3>Cuentos de Killa</h3>
-    <nav>
-      <a routerLink="/admin/dashboard" routerLinkActive="active" (click)="toggleMenu(false)">Dashboard</a>
-      <a routerLink="/admin/cuentos" routerLinkActive="active" (click)="toggleMenu(false)">Cuentos</a>
-      <a routerLink="/admin/pedidos" routerLinkActive="active" (click)="toggleMenu(false)">Pedidos</a>
-      <a routerLink="/admin/usuarios" routerLinkActive="active" (click)="toggleMenu(false)">Usuarios</a>
-    </nav>
-  </aside>
+  <header class="header">
+    <img src="assets/killa.bmp" alt="Cuentos de Killa" class="logo" />
+    <button class="btn-menu" (click)="toggleMenu()">☰</button>
+  </header>
 
-  <main class="content">
-    <router-outlet></router-outlet>
-  </main>
-  <div class="overlay" [class.show]="menuAbierto" (click)="toggleMenu(false)"></div>
+  <div class="main-container">
+    <aside class="sidebar" [class.open]="menuAbierto">
+      <nav>
+        <ul class="admin-links">
+          <li><a routerLink="/admin/dashboard" routerLinkActive="active" (click)="toggleMenu(false)">Dashboard</a></li>
+          <li><a routerLink="/admin/cuentos" routerLinkActive="active" (click)="toggleMenu(false)">Cuentos</a></li>
+          <li><a routerLink="/admin/pedidos" routerLinkActive="active" (click)="toggleMenu(false)">Pedidos</a></li>
+          <li><a routerLink="/admin/usuarios" routerLinkActive="active" (click)="toggleMenu(false)">Usuarios</a></li>
+        </ul>
+        <hr />
+        <ul class="client-links">
+          <li><a routerLink="/home" (click)="toggleMenu(false)">Inicio</a></li>
+          <li><a routerLink="/carrito" (click)="toggleMenu(false)">Carrito</a></li>
+          <li><a routerLink="/pedidos" (click)="toggleMenu(false)">Mis Pedidos</a></li>
+          <li><a routerLink="/perfil" (click)="toggleMenu(false)">Perfil</a></li>
+        </ul>
+      </nav>
+    </aside>
+
+    <main class="content">
+      <router-outlet></router-outlet>
+    </main>
+    <div class="overlay" [class.show]="menuAbierto" (click)="toggleMenu(false)"></div>
+  </div>
 </div>
   

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
@@ -1,44 +1,61 @@
-
 .admin-layout {
   display: flex;
+  flex-direction: column;
   height: 100vh;
 
-  .menu-toggle {
-    display: none;
-    position: fixed;
-    top: 1rem;
-    left: 1rem;
-    background: #a66e38;
+  .header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background-color: #a66e38;
+    padding: 0.5rem 1rem;
     color: #fff;
-    border: none;
-    padding: 0.5rem;
-    font-size: 1.5rem;
-    border-radius: 4px;
+    position: sticky;
+    top: 0;
     z-index: 1100;
+  }
+
+  .logo {
+    height: 32px;
+    margin-right: 0.5rem;
+  }
+
+  .btn-menu {
+    background: none;
+    border: none;
+    color: #fff;
+    font-size: 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     cursor: pointer;
+    display: none;
+  }
+
+  .main-container {
+    flex: 1;
+    display: flex;
   }
 
   .sidebar {
     width: 240px;
     background-color: #a66e38;
-    color: white;
+    color: #fff;
     padding: 2rem 1rem;
 
-    h3 {
-      font-size: 1.5rem;
-      margin-bottom: 2rem;
+    nav ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+
+      li {
+        margin: 0.5rem 0;
+      }
     }
 
-    nav a {
-      display: block;
-      color: white;
-      text-decoration: none;
+    hr {
+      border-color: rgba(255,255,255,0.3);
       margin: 1rem 0;
-      font-weight: 500;
-
-      &.active {
-        text-decoration: underline;
-      }
     }
   }
 
@@ -56,40 +73,60 @@
 
 @media (max-width: 768px) {
   .admin-layout {
-    .menu-toggle {
+    .btn-menu {
       display: block;
     }
 
-    $nav-height: 60px; // altura aproximada del navbar
-
     .sidebar {
       position: fixed;
-      left: -240px;
-      top: $nav-height;
-      height: calc(100% - $nav-height);
-      transition: left 0.3s;
+      top: 0;
+      left: 0;
+      height: 100%;
+      transform: translateX(-100%);
+      transition: transform 0.25s;
       z-index: 1000;
     }
 
     &.menu-open {
       .sidebar {
-        left: 0;
+        transform: translateX(0);
       }
 
       .overlay {
         display: block;
         position: fixed;
-        top: $nav-height;
+        top: 0;
         left: 0;
         width: 100%;
-        height: calc(100% - $nav-height);
+        height: 100%;
         background: rgba(0, 0, 0, 0.5);
         z-index: 900;
       }
     }
+
     .content {
       padding: 1rem;
     }
   }
 }
-  
+
+.sidebar .badge {
+  background-color: #FFEAD9;
+  color: #A66E38;
+  border-radius: 50%;
+  padding: 0 0.5rem;
+  font-weight: bold;
+  margin-left: 0.5rem;
+}
+
+.sidebar .avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: #fff;
+  color: #A66E38;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- add mobile header with logo and menu button
- combine admin and client links in sidebar
- style sidebar using Killa palette

## Testing
- `npm test --silent` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643dfaf1a88327b941844d377239ef