### PR TITLE
Enhance admin sidebar and login modal

### DIFF
--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -49,7 +49,7 @@ export class NavbarComponent implements OnInit {
     this.dialog.open(LoginComponent, {
       maxWidth: '50vw',
       width: '80%',
-      panelClass: 'custom-login-dialog'
+      panelClass: 'login-modal'
     });
   }
   ngOnInit(): void {

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.html
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.html
@@ -1,7 +1,7 @@
 <div class="admin-layout" [class.menu-open]="menuAbierto">
   <header class="header">
     <img src="assets/killa.bmp" alt="Cuentos de Killa" class="logo" />
-    <button class="btn-menu" (click)="toggleMenu()">☰</button>
+    <button class="btn-menu" aria-label="Menú" (click)="toggleMenu()">☰</button>
   </header>
 
   <div class="main-container">
@@ -16,9 +16,17 @@
         <hr />
         <ul class="client-links">
           <li><a routerLink="/home" (click)="toggleMenu(false)">Inicio</a></li>
-          <li><a routerLink="/carrito" (click)="toggleMenu(false)">Carrito</a></li>
+          <li>
+            <a routerLink="/carrito" (click)="toggleMenu(false)">
+              Carrito
+              <span class="badge" *ngIf="cantidadTotalItems > 0">{{ cantidadTotalItems }}</span>
+            </a>
+          </li>
           <li><a routerLink="/pedidos" (click)="toggleMenu(false)">Mis Pedidos</a></li>
           <li><a routerLink="/perfil" (click)="toggleMenu(false)">Perfil</a></li>
+          <li *ngIf="user?.nombre" class="avatar-wrapper">
+            <div class="avatar" [attr.title]="user?.nombre || ''">{{ user?.nombre ? user.nombre.charAt(0) : '' }}</div>
+          </li>
         </ul>
       </nav>
     </aside>

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
@@ -1,5 +1,9 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterModule } from '@angular/router';
+import { CartService } from '../../../../services/carrito.service';
+import { AuthService } from '../../../../services/auth.service';
+import { User } from '../../../../model/user.model';
+import { Cuento } from '../../../../model/cuento.model';
 
 @Component({
   selector: 'app-admin-layout',
@@ -8,8 +12,22 @@ import { RouterModule } from '@angular/router';
   templateUrl: './admin-layout.component.html',
   styleUrls: ['./admin-layout.component.scss']
 })
-export class AdminLayoutComponent {
+export class AdminLayoutComponent implements OnInit {
   menuAbierto = false;
+  itemsCarrito: { cuento: Cuento, cantidad: number }[] = [];
+  user: User | null = null;
+
+  constructor(private cartService: CartService, private authService: AuthService) {}
+
+  ngOnInit(): void {
+    this.cartService.items$.subscribe(items => this.itemsCarrito = items);
+    this.user = this.authService.getUser();
+    this.authService.usuarioLogueado$.subscribe(u => this.user = u);
+  }
+
+  get cantidadTotalItems(): number {
+    return this.itemsCarrito.reduce((t, i) => t + i.cantidad, 0);
+  }
 
   toggleMenu(force?: boolean) {
     this.menuAbierto = force !== undefined ? force : !this.menuAbierto;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -17,3 +17,7 @@ body {
 * {
   box-sizing: border-box;
 }
+
+.login-modal .mat-dialog-container {
+  z-index: 1002;
+}


### PR DESCRIPTION
## Summary
- add aria label and cart badge/avatar to admin sidebar
- handle cart and user state in admin layout
- raise login modal above sidebar
- fix null checks for user info

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864407e8c088327aa3977f6fd753cc7