### PR TITLE
Implement Admin Dashboard layout refinements

### DIFF
--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
@@ -1,12 +1,13 @@
-<div class="dashboard-container">
+<div class="dashboard-content">
   <h2>Bienvenido, Admin!</h2>
 
   <div class="loading-indicator" *ngIf="isLoading">
-    <p>Cargando datos...</p>
+    <div class="spinner"></div>
   </div>
 
   <div class="error-mensaje" *ngIf="errorMensaje">
     <p>{{ errorMensaje }}</p>
+    <button (click)="cargarEstadisticas()">Reintentar</button>
   </div>
 
   <div class="cards" *ngIf="!isLoading && !errorMensaje">

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.scss
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.scss
@@ -1,56 +1,81 @@
-// admin-dashboard.component.scss
+.dashboard-content {
+  padding: 1.5rem;
+  background-color: #FEF6E8;
+  color: #4E3B15;
 
-.dashboard-container {
-    padding: 2rem;
-    background-color: #fffaf5;
-  
   h2 {
     font-size: 24px;
+    font-weight: bold;
+    color: #38290F;
+    margin-bottom: 1.5rem;
+  }
+
+  .cards {
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+
+  .card {
+    background-color: #ffecb3;
+    border-radius: 12px;
+    padding: 1rem;
+    flex: 1;
+    min-width: 180px;
+    text-align: center;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+
+    h4 {
+      font-size: 14px;
+      margin-bottom: 0.5rem;
+      color: #704b26;
+    }
+
+    p {
+      font-size: 24px;
       font-weight: bold;
-      color: #3c2f2f;
-      margin-bottom: 1.5rem;
-    }
-  
-    .cards {
-      display: flex;
-      gap: 1rem;
-      flex-wrap: wrap;
-    }
-  
-    .card {
-      background-color: #ffecb3;
-      border-radius: 12px;
-      padding: 1rem;
-      flex: 1;
-      min-width: 180px;
-      text-align: center;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-  
-      h4 {
-        font-size: 14px;
-        margin-bottom: 0.5rem;
-        color: #704b26;
-      }
-  
-      p {
-        font-size: 24px;
-        font-weight: bold;
-        color: #a66e38;
-      }
+      color: #a66e38;
     }
   }
 
-  @media (max-width: 600px) {
-    .cards {
-      flex-direction: column;
-      align-items: stretch;
-    }
+  .loading-indicator {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding: 2rem 0;
 
-    h2 {
-      font-size: 20px;
-    }
-    .card p {
-      font-size: 20px;
+    .spinner {
+      border: 4px solid #f3f3f3;
+      border-top: 4px solid #a66e38;
+      border-radius: 50%;
+      width: 40px;
+      height: 40px;
+      animation: spin 1s linear infinite;
     }
   }
-  
+
+  .error-mensaje {
+    text-align: center;
+    background: #ffd3d3;
+    padding: 1rem;
+    border-radius: 8px;
+    margin-bottom: 1rem;
+
+    p {
+      margin: 0 0 0.5rem 0;
+    }
+
+    button {
+      background: #a66e38;
+      color: #fff;
+      border: none;
+      padding: 0.5rem 1rem;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+  }
+}
+
+@keyframes spin {
+  100% { transform: rotate(360deg); }
+}

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.ts
@@ -26,6 +26,11 @@ export class AdminDashboardComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
+    this.cargarEstadisticas();
+  }
+
+  cargarEstadisticas(): void {
+    this.errorMensaje = null;
     this.isLoading = true;
     forkJoin([
       this.cuentoService.obtenerCuentos(),
@@ -39,7 +44,7 @@ export class AdminDashboardComponent implements OnInit {
         this.isLoading = false;
       },
       error: () => {
-        this.errorMensaje = 'No se pudieron cargar las estadísticas';
+        this.errorMensaje = 'Error al cargar estadísticas. Reintentar';
         this.isLoading = false;
       }
     });

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.html
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.html
@@ -1,12 +1,6 @@
-<div class="admin-layout" [class.menu-open]="menuAbierto">
-  <header class="header">
-    <img src="assets/killa.bmp" alt="Cuentos de Killa" class="logo" />
-    <button class="btn-menu" (click)="toggleMenu()">☰</button>
-  </header>
-
-  <div class="main-container">
-    <aside class="sidebar" [class.open]="menuAbierto">
-      <nav>
+<div class="admin-layout">
+  <aside class="sidebar">
+    <nav>
         <ul class="admin-links">
           <li><a routerLink="/admin/dashboard" routerLinkActive="active" (click)="toggleMenu(false)">Dashboard</a></li>
           <li><a routerLink="/admin/cuentos" routerLinkActive="active" (click)="toggleMenu(false)">Cuentos</a></li>
@@ -21,12 +15,10 @@
           <li><a routerLink="/perfil" (click)="toggleMenu(false)">Perfil</a></li>
         </ul>
       </nav>
-    </aside>
+  </aside>
 
-    <main class="content">
-      <router-outlet></router-outlet>
-    </main>
-    <div class="overlay" [class.show]="menuAbierto" (click)="toggleMenu(false)"></div>
-  </div>
+  <main class="content">
+    <router-outlet></router-outlet>
+  </main>
 </div>
   

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
@@ -1,113 +1,41 @@
+
 .admin-layout {
   display: flex;
-  flex-direction: column;
+}
+
+.sidebar {
+  width: 240px;
   height: 100vh;
+  position: fixed;
+  left: 0;
+  top: 0;
+  background-color: #a66e38;
+  color: #fff;
+  padding: 2rem 1rem;
 
-  .header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    background-color: #a66e38;
-    padding: 0.5rem 1rem;
-    color: #fff;
-    position: sticky;
-    top: 0;
-    z-index: 1100;
-  }
+  nav ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
 
-  .logo {
-    height: 32px;
-    margin-right: 0.5rem;
-  }
-
-  .btn-menu {
-    background: none;
-    border: none;
-    color: #fff;
-    font-size: 1.5rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    display: none;
-  }
-
-  .main-container {
-    flex: 1;
-    display: flex;
-  }
-
-  .sidebar {
-    width: 240px;
-    background-color: #a66e38;
-    color: #fff;
-    padding: 2rem 1rem;
-
-    nav ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-
-      li {
-        margin: 0.5rem 0;
-      }
-    }
-
-    hr {
-      border-color: rgba(255,255,255,0.3);
-      margin: 1rem 0;
+    li {
+      margin: 0.5rem 0;
     }
   }
 
-  .content {
-    flex: 1;
-    padding: 2rem;
-    background-color: #fffaf5;
-    overflow-y: auto;
-  }
-
-  .overlay {
-    display: none;
+  hr {
+    border-color: rgba(255, 255, 255, 0.3);
+    margin: 1rem 0;
   }
 }
 
-@media (max-width: 768px) {
-  .admin-layout {
-    .btn-menu {
-      display: block;
-    }
-
-    .sidebar {
-      position: fixed;
-      top: 0;
-      left: 0;
-      height: 100%;
-      transform: translateX(-100%);
-      transition: transform 0.25s;
-      z-index: 1000;
-    }
-
-    &.menu-open {
-      .sidebar {
-        transform: translateX(0);
-      }
-
-      .overlay {
-        display: block;
-        position: fixed;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        background: rgba(0, 0, 0, 0.5);
-        z-index: 900;
-      }
-    }
-
-    .content {
-      padding: 1rem;
-    }
-  }
+.content {
+  margin-left: 240px;
+  padding: 1rem;
+  background-color: #FEF6E8;
+  flex: 1;
+  min-height: 100vh;
+  overflow-y: auto;
 }
 
 .sidebar .badge {

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
@@ -9,9 +9,5 @@ import { RouterModule } from '@angular/router';
   styleUrls: ['./admin-layout.component.scss']
 })
 export class AdminLayoutComponent {
-  menuAbierto = false;
-
-  toggleMenu(force?: boolean) {
-    this.menuAbierto = force !== undefined ? force : !this.menuAbierto;
-  }
+  // Layout simplificado sin barra superior ni menú colapsable
 }


### PR DESCRIPTION
## Summary
- simplify admin layout to avoid duplicate headers
- fix admin sidebar layout and colors
- update dashboard styles and loading/error states
- add retry logic when stats fail

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864419813a48327b7c12ede44747563