### PR TITLE
Add admin dropdown menu

### DIFF
--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.html
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.html
@@ -1,26 +1,19 @@
-<div class="admin-layout" [class.menu-open]="menuAbierto">
-  <header class="header">
-    <img src="assets/killa.bmp" alt="Cuentos de Killa" class="logo" />
-    <button class="btn-menu" aria-label="Menú" (click)="toggleMenu()">☰</button>
-  </header>
-
-  <div class="layout">
-    <aside class="sidebar" [class.open]="menuAbierto">
-      <nav role="navigation">
-        <ul class="admin-links">
-          <li><a routerLink="/admin/dashboard" routerLinkActive="active" >Dashboard</a></li>
-          <li><a routerLink="/admin/cuentos" routerLinkActive="active" >Cuentos</a></li>
-          <li><a routerLink="/admin/pedidos" routerLinkActive="active" >Pedidos</a></li>
-          <li><a routerLink="/admin/usuarios" routerLinkActive="active" >Usuarios</a></li>
-        </ul>
-        <hr />
-        <ul class="client-links">
-        </ul>
-      </nav>
-    </aside>
-    <div class="overlay" [class.show]="menuAbierto" (click)="toggleMenu(false)"></div>
-    <main class="content" role="main">
-      <router-outlet></router-outlet>
-    </main>
-  </div>
-</div>
+<nav class="navbar admin-navbar" role="navigation" aria-label="Menú de administración">
+  <a class="navbar-brand">
+    <img src="assets/killa.bmp" alt="Cuentos de Killa" class="logo-img" />
+    <span class="brand-text">Cuentos de Killa</span>
+  </a>
+  <button class="hamburger" aria-label="Menú" (click)="toggleMenu()">☰</button>
+  <ul class="nav-links" [class.open]="menuAbierto">
+    <li class="close-wrapper" *ngIf="menuAbierto">
+      <button class="close-menu" aria-label="Cerrar" (click)="toggleMenu(false)">✖</button>
+    </li>
+    <li><a routerLink="/admin/dashboard" routerLinkActive="active" (click)="toggleMenu(false)">Dashboard</a></li>
+    <li><a routerLink="/admin/cuentos" routerLinkActive="active" (click)="toggleMenu(false)">Cuentos</a></li>
+    <li><a routerLink="/admin/pedidos" routerLinkActive="active" (click)="toggleMenu(false)">Pedidos</a></li>
+    <li><a routerLink="/admin/usuarios" routerLinkActive="active" (click)="toggleMenu(false)">Usuarios</a></li>
+  </ul>
+</nav>
+<main class="admin-content" role="main">
+  <router-outlet></router-outlet>
+</main>

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
@@ -1,111 +1,106 @@
+@import '../../../../styles/variables';
 
-.admin-layout {
-  display: block;
-}
-
-.layout {
-  display: flex;
-}
-
-.header {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  background: #a66e38;
-  color: #fff;
-  padding: 0.5rem 1rem;
+.admin-navbar {
+  background-color: $primary;
+  padding: 10px 20px;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  z-index: 100;
-}
-
-.sidebar {
-  width: 240px;
-  height: 100vh;
-  position: fixed;
-  left: 0;
-  top: 0;
-  background-color: #a66e38;
   color: #fff;
-  padding: 2rem 1rem;
-  transform: translateX(-100%);
-  transition: transform 0.3s ease;
-  z-index: 200;
-
-  &.open {
-    transform: translateX(0);
-  }
-
-  nav ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-
-    li {
-      margin: 0.5rem 0;
-    }
-  }
-
-  hr {
-    border-color: rgba(255, 255, 255, 0.3);
-    margin: 1rem 0;
-  }
-}
-
-.overlay {
-  position: fixed;
+  position: sticky;
   top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.3);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.3s ease;
-  z-index: 150;
-
-  &.show {
-    opacity: 1;
-    pointer-events: all;
-  }
+  z-index: 1100;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
-.content {
-  margin-left: 240px;
-  padding: 1rem;
-  background-color: #FEF6E8;
-  flex: 1;
-  min-height: 100vh;
-  overflow-y: auto;
-  padding-top: 3rem; /* space for fixed header */
-}
-
-.sidebar .badge {
-  background-color: #FFEAD9;
-  color: #A66E38;
-  border-radius: 50%;
-  padding: 0 0.5rem;
-  font-weight: bold;
-  margin-left: 0.5rem;
-}
-
-.sidebar .avatar {
-  width: 32px;
-  height: 32px;
-  border-radius: 50%;
-  background: #fff;
-  color: #A66E38;
+.admin-navbar .navbar-brand {
   display: flex;
   align-items: center;
-  justify-content: center;
+  gap: 10px;
+  text-decoration: none;
+  background-color: transparent;
+}
+
+.admin-navbar .logo-img {
+  height: 40px;
+  width: auto;
+  object-fit: contain;
+}
+
+.admin-navbar .brand-text {
+  font-size: 1.2rem;
   font-weight: bold;
+  color: #fff;
+}
+
+.admin-navbar .nav-links {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin: 0;
+  padding: 0;
+}
+
+.admin-navbar .nav-links li {
+  display: flex;
+  align-items: center;
+}
+
+.admin-navbar .nav-links a {
+  color: #fff;
+  text-decoration: none;
+  font-weight: bold;
+  transition: color 0.3s ease;
+}
+
+.admin-navbar .nav-links a:hover {
+  color: #ffeead;
+}
+
+.close-menu,
+.hamburger {
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.close-menu {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: none;
 }
 
 @media (max-width: 768px) {
-  .content {
-    margin-left: 0;
+  .admin-navbar .nav-links {
+    position: fixed;
+    top: 0;
+    right: 0;
+    height: 100%;
+    width: 200px;
+    background: $primary;
+    flex-direction: column;
+    padding-top: 4rem;
+    transform: translateX(100%);
+    transition: transform 0.3s ease;
+  }
+
+  .admin-navbar .nav-links.open {
+    transform: translateX(0);
+  }
+
+  .close-menu {
+    display: block;
+  }
+
+  .hamburger {
+    display: block;
   }
 }
 
+.admin-content {
+  padding: 1rem;
+}

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
@@ -1,33 +1,15 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { CartService } from '../../../../services/carrito.service';
-import { AuthService } from '../../../../services/auth.service';
-import { User } from '../../../../model/user.model';
-import { Cuento } from '../../../../model/cuento.model';
 
 @Component({
   selector: 'app-admin-layout',
-  // standalone: true,
-  // imports: [RouterModule],
+  standalone: true,
+  imports: [RouterModule],
   templateUrl: './admin-layout.component.html',
   styleUrls: ['./admin-layout.component.scss']
 })
-export class AdminLayoutComponent implements OnInit {
+export class AdminLayoutComponent {
   menuAbierto = false;
-  itemsCarrito: { cuento: Cuento, cantidad: number }[] = [];
-  user: User | null = null;
-
-  constructor(private cartService: CartService, private authService: AuthService) {}
-
-  ngOnInit(): void {
-    this.cartService.items$.subscribe(items => this.itemsCarrito = items);
-    this.user = this.authService.getUser();
-    this.authService.usuarioLogueado$.subscribe(u => this.user = u);
-  }
-
-  get cantidadTotalItems(): number {
-    return this.itemsCarrito.reduce((t, i) => t + i.cantidad, 0);
-  }
 
   toggleMenu(force?: boolean) {
     this.menuAbierto = force !== undefined ? force : !this.menuAbierto;

--- a/src/app/components/pages/admin/admin.module.ts
+++ b/src/app/components/pages/admin/admin.module.ts
@@ -35,7 +35,6 @@ const routes: Routes = [
 
 @NgModule({
   declarations: [
-    AdminLayoutComponent,
     AdminDashboardComponent,
     AdminCuentosComponent,
     AdminPedidosComponent,
@@ -50,7 +49,8 @@ const routes: Routes = [
     // HttpClientModule,
     RouterModule,
     RouterModule.forChild(routes),
-    SharedModule
-]
+    SharedModule,
+    AdminLayoutComponent
+  ]
 })
 export class AdminModule {}


### PR DESCRIPTION
## Summary
- replace old sidebar admin menu with a top dropdown nav
- convert `AdminLayoutComponent` to standalone and simplify

## Testing
- `npm test --silent -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647695f844832786ac0a81b1a805cb