### PR TITLE
Fix voucher upload form fields

### DIFF
--- a/src/app/services/pedido.service.ts
+++ b/src/app/services/pedido.service.ts
@@ -18,7 +18,9 @@ export class PedidoService {
 
   uploadVoucher(pedidoId: number, voucherFile: File): Observable<any> {
     const formData = new FormData();
-    formData.append('voucherFile', voucherFile);
+    // Backend expects these specific field names
+    formData.append('file', voucherFile);
+    formData.append('idpedido', pedidoId.toString());
     return this.http.post(`${this.apiUrl}/${pedidoId}/voucher`, formData);
   }
 


### PR DESCRIPTION
## Summary
- send voucher using `file` and `idpedido` fields

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68647da86e988327afd19032237e67a6