### PR TITLE
List admin users on dashboard

### DIFF
--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
@@ -30,4 +30,16 @@
       </div>
     </ng-container>
   </section>
+
+  <section class="users-section" *ngIf="!isLoading && !errorMensaje">
+    <h3>Usuarios registrados</h3>
+    <div class="users-grid">
+      <div class="user-card" *ngFor="let user of usuarios">
+        <p class="user-name">{{ user.nombre }} {{ user.apellido }}</p>
+        <p class="user-email">{{ user.email }}</p>
+        <p class="user-phone">{{ user.telefono }}</p>
+        <p class="user-role">{{ user.role }}</p>
+      </div>
+    </div>
+  </section>
 </div>

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.scss
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.scss
@@ -87,11 +87,51 @@
       cursor: pointer;
     }
   }
+
+  .users-section {
+    margin-top: 2rem;
+
+    h3 {
+      margin-bottom: 1rem;
+      font-size: 20px;
+      color: #38290F;
+    }
+
+    .users-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 1rem;
+    }
+
+    .user-card {
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+      padding: 1rem;
+
+      .user-name {
+        font-weight: 600;
+        color: #a66e38;
+      }
+
+      p {
+        margin: 0.25rem 0;
+        font-size: 14px;
+        color: #704b26;
+      }
+    }
+  }
 }
 
 @media (max-width: 768px) {
   .stats-grid {
     grid-template-columns: 1fr;
+  }
+
+  .users-section {
+    .users-grid {
+      grid-template-columns: 1fr;
+    }
   }
 }
 

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.spec.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.spec.ts
@@ -48,6 +48,7 @@ describe('AdminDashboardComponent', () => {
     expect(component.cuentosPublicados).toBe(2);
     expect(component.pedidosEnProceso).toBe(1);
     expect(component.usuariosRegistrados).toBe(3);
+    expect(component.usuarios.length).toBe(3);
     expect(component.isLoading).toBeFalse();
     expect(component.errorMensaje).toBeNull();
   });
@@ -59,7 +60,7 @@ describe('AdminDashboardComponent', () => {
 
     fixture.detectChanges();
 
-    expect(component.errorMensaje).toBe('No se pudieron cargar las estadísticas');
+    expect(component.errorMensaje).toBe('Error al cargar estadísticas. Reintentar');
     expect(component.isLoading).toBeFalse();
   });
 });

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.ts
@@ -3,6 +3,7 @@ import { forkJoin } from 'rxjs';
 import { CuentoService } from '../../../../services/cuento.service';
 import { PedidoService } from '../../../../services/pedido.service';
 import { UserService } from '../../../../services/user.service';
+import { User } from '../../../../model/user.model';
 
 @Component({
   selector: 'app-admin-dashboard',
@@ -18,6 +19,7 @@ export class AdminDashboardComponent implements OnInit {
   ventasTotales = 0;
   isLoading = true;
   errorMensaje: string | null = null;
+  usuarios: User[] = [];
 
   constructor(
     private cuentoService: CuentoService,
@@ -41,6 +43,7 @@ export class AdminDashboardComponent implements OnInit {
         this.cuentosPublicados = cuentos.length;
         this.pedidosEnProceso = pedidos.length;
         this.usuariosRegistrados = usuarios.length;
+        this.usuarios = usuarios;
         this.isLoading = false;
       },
       error: () => {


### PR DESCRIPTION
## Summary
- show users in Admin Dashboard
- style the user grid to match the current dashboard
- test dashboard now expects user list

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864aa18f5ec8327b29cc687d04e1534