### PR TITLE
Fix lazy load directive

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@angular/platform-server": "^18.0.0",
     "@angular/router": "^18.0.0",
     "@angular/ssr": "^18.0.0",
+    "helmet": "^7.0.0",
     "express": "^4.18.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",

--- a/server.ts
+++ b/server.ts
@@ -4,10 +4,21 @@ import express from 'express';
 import { fileURLToPath } from 'node:url';
 import { dirname, join, resolve } from 'node:path';
 import bootstrap from './src/main.server';
+import helmet from 'helmet';
 
 // The Express app is exported so that it can be used by serverless Functions.
 export function app(): express.Express {
   const server = express();
+  server.use(helmet());
+  server.use(
+    helmet.contentSecurityPolicy({
+      directives: {
+        defaultSrc: ["'self'"],
+        imgSrc: ["'self'", 'data:'],
+      },
+    })
+  );
+  server.use(helmet.hsts({ maxAge: 31536000 }));
   const serverDistFolder = dirname(fileURLToPath(import.meta.url));
   const browserDistFolder = resolve(serverDistFolder, '../browser');
   const indexHtml = join(serverDistFolder, 'index.server.html');

--- a/src/app/components/cuento-card/cuento-card.component.html
+++ b/src/app/components/cuento-card/cuento-card.component.html
@@ -1,7 +1,7 @@
 <div class="cuento-card">
   <span class="badge" *ngIf="isNuevo">Nuevo</span>
   <div class="image-wrapper">
-    <img [src]="cuento.imagenUrl || 'assets/placeholder-cuento.jpg'" alt="{{cuento.titulo}}" loading="lazy" (load)="imagenCargada()" (error)="cargarImagenPlaceholder($event)">
+    <img [appLazyLoad]="cuento.imagenUrl || 'assets/placeholder-cuento.jpg'" alt="{{cuento.titulo}}" (load)="imagenCargada()" (error)="cargarImagenPlaceholder($event)">
     <div class="image-placeholder" *ngIf="cargandoImagen"></div>
   </div>
   <h3>Titulo: {{ cuento.titulo }}</h3>
@@ -19,10 +19,10 @@
   </div>
   <div class="share-buttons">
     <button aria-label="Compartir por WhatsApp" (click)="compartir('whatsapp')">
-      <img src="assets/whatsapp.svg" alt="WhatsApp">
+      <img appLazyLoad="assets/whatsapp.svg" alt="WhatsApp">
     </button>
     <button aria-label="Compartir por Instagram" (click)="compartir('instagram')">
-      <img src="assets/instagram.svg" alt="Instagram">
+      <img appLazyLoad="assets/instagram.svg" alt="Instagram">
     </button>
   </div>
 </div>

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -1,6 +1,6 @@
 <nav class="navbar" role="navigation" aria-label="Navegación principal">
   <a class="navbar-brand">
-    <img src="assets/killa.bmp" alt="Cuentos de Killa" class="logo-img" />
+    <img appLazyLoad="assets/killa.bmp" alt="Cuentos de Killa" class="logo-img" />
     <span class="brand-text">Cuentos de Killa</span>
   </a>
   <button class="hamburger" aria-label="Menú" (click)="toggleMenu()">☰</button>

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -9,6 +9,7 @@ import { AuthService } from '../../services/auth.service';
 import { CommonModule } from '@angular/common';
 import { Cuento } from '../../model/cuento.model';
 import { User } from '../../model/user.model';
+import { LazyLoadImageDirective } from '../../directives/lazy-load-image.directive';
 
 
 
@@ -21,6 +22,7 @@ import { User } from '../../model/user.model';
   imports: [
     CommonModule, // 🔥 necesario para *ngIf, *ngFor
     RouterModule, // habilita routerLink en la plantilla
+    LazyLoadImageDirective,
     // otros imports que tengas como MatDialogModule, etc.
   ]
 })

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
@@ -1,7 +1,7 @@
 <div class="dashboard-content">
   <h2>Bienvenido, Admin!</h2>
 
-  <img src="assets/libros_killa.png" alt="Banner" class="dashboard-banner" />
+  <img appLazyLoad="assets/libros_killa.png" alt="Banner" class="dashboard-banner" />
 
   <div *ngIf="errorMensaje" class="error-mensaje">
     <p>{{ errorMensaje }}</p>

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.html
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.html
@@ -1,6 +1,6 @@
 <nav class="navbar admin-navbar" role="navigation" aria-label="Menú de administración">
   <a class="navbar-brand">
-    <img src="assets/killa.bmp" alt="Cuentos de Killa" class="logo-img" />
+    <img appLazyLoad="assets/killa.bmp" alt="Cuentos de Killa" class="logo-img" />
     <span class="brand-text">Cuentos de Killa</span>
   </a>
   <button class="hamburger" aria-label="Menú" (click)="toggleMenu()">☰</button>

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
@@ -1,11 +1,12 @@
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import { LazyLoadImageDirective } from '../../../../directives/lazy-load-image.directive';
 
 @Component({
   selector: 'app-admin-layout',
   standalone: true,
-  imports: [RouterModule, CommonModule],
+  imports: [RouterModule, CommonModule, LazyLoadImageDirective],
   templateUrl: './admin-layout.component.html',
   styleUrls: ['./admin-layout.component.scss']
 })

--- a/src/app/components/pages/login/login.component.html
+++ b/src/app/components/pages/login/login.component.html
@@ -17,6 +17,6 @@
   </div>
 
   <div class="ilustracion">
-    <img src="/assets/libros_killa.png" alt="Ilustración lectura" />
+    <img appLazyLoad="/assets/libros_killa.png" alt="Ilustración lectura" />
   </div>
 </div>

--- a/src/app/components/pages/login/login.component.ts
+++ b/src/app/components/pages/login/login.component.ts
@@ -5,10 +5,11 @@ import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService} from '../../../services/auth.service';
 import { MatDialogRef } from '@angular/material/dialog';
+import { LazyLoadImageDirective } from '../../../directives/lazy-load-image.directive';
 
 @Component({
   standalone: true,
-  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, LazyLoadImageDirective],
   selector: 'app-login',
   templateUrl: './login.component.html',
   styleUrls: ['./login.component.scss']

--- a/src/app/components/pages/order-detail/order-detail.component.html
+++ b/src/app/components/pages/order-detail/order-detail.component.html
@@ -37,7 +37,7 @@
       <div *ngIf="pedido?.items && pedido.items.length > 0; else noItems">
         <div *ngFor="let item of pedido?.items" class="item-card">
           <div class="item-imagen">
-            <img [src]="item?.imagenUrl || 'assets/images/placeholder-cuento.png'" [alt]="item?.nombreCuento" class="img-fluid">
+            <img [appLazyLoad]="item?.imagenUrl || 'assets/images/placeholder-cuento.png'" [alt]="item?.nombreCuento" class="img-fluid">
           </div>
           <div class="item-detalles">
             <h4>{{ item.nombreCuento }}</h4>

--- a/src/app/components/pages/order-detail/order-detail.component.ts
+++ b/src/app/components/pages/order-detail/order-detail.component.ts
@@ -3,11 +3,12 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { Pedido, PedidoItem } from '../../../model/pedido.model';
 import { PedidoService } from '../../../services/pedido.service';
 import { CommonModule } from '@angular/common'; // Import CommonModule
+import { LazyLoadImageDirective } from '../../../directives/lazy-load-image.directive';
 
 @Component({
   selector: 'app-order-detail',
   standalone: true, // Ensure standalone is true
-  imports: [CommonModule], // Add CommonModule here
+  imports: [CommonModule, LazyLoadImageDirective], // Add CommonModule here
   templateUrl: './order-detail.component.html',
   styleUrls: ['./order-detail.component.scss']
 })

--- a/src/app/components/pages/register/register.component.html
+++ b/src/app/components/pages/register/register.component.html
@@ -30,6 +30,6 @@
     </p>
   </div>
   <div class="ilustracion">
-    <img src="/assets/libros_killa.png" alt="Ilustración lectura" />
+    <img appLazyLoad="/assets/libros_killa.png" alt="Ilustración lectura" />
   </div>
 </div>

--- a/src/app/components/pages/register/register.component.ts
+++ b/src/app/components/pages/register/register.component.ts
@@ -3,11 +3,12 @@ import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
 import { AuthService } from '../../../services/auth.service';
+import { LazyLoadImageDirective } from '../../../directives/lazy-load-image.directive';
 
 @Component({
   standalone: true,
   selector: 'app-register',
-  imports: [CommonModule, ReactiveFormsModule, RouterModule],
+  imports: [CommonModule, ReactiveFormsModule, RouterModule, LazyLoadImageDirective],
   templateUrl: './register.component.html',
   styleUrls: ['./register.component.scss']
 })

--- a/src/app/components/shared.module.ts
+++ b/src/app/components/shared.module.ts
@@ -2,6 +2,7 @@ import { NgModule ,CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { Routes } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { CuentoCardComponent } from './cuento-card/cuento-card.component';
+import { LazyLoadImageDirective } from '../directives/lazy-load-image.directive';
 // import { CuentosGridComponent } from './cuentos-grid/cuentos-grid.component';
 
 const routes: Routes = [
@@ -9,9 +10,9 @@ const routes: Routes = [
 ];
 
 @NgModule({
-    declarations: [CuentoCardComponent],
-  imports: [CommonModule ],
-  exports: [CuentoCardComponent], // 🔥 esto es clave
-  schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
+  declarations: [CuentoCardComponent, LazyLoadImageDirective],
+  imports: [CommonModule],
+  exports: [CuentoCardComponent, LazyLoadImageDirective], // 🔥 esto es clave
+  schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
 export class SharedModule {}

--- a/src/app/directives/lazy-load-image.directive.ts
+++ b/src/app/directives/lazy-load-image.directive.ts
@@ -1,0 +1,35 @@
+import { Directive, ElementRef, Input, OnDestroy, AfterViewInit } from '@angular/core';
+
+@Directive({
+  selector: 'img[appLazyLoad]',
+  standalone: true,
+})
+export class LazyLoadImageDirective implements AfterViewInit, OnDestroy {
+  @Input('appLazyLoad') src = '';
+  private observer?: IntersectionObserver;
+
+  constructor(private el: ElementRef<HTMLImageElement>) {}
+
+  ngAfterViewInit(): void {
+    const img = this.el.nativeElement;
+    img.setAttribute('loading', 'lazy');
+
+    if ('IntersectionObserver' in window) {
+      this.observer = new IntersectionObserver(entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            img.src = this.src;
+            this.observer?.disconnect();
+          }
+        });
+      });
+      this.observer.observe(img);
+    } else {
+      img.src = this.src;
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.observer?.disconnect();
+  }
+}


### PR DESCRIPTION
## Summary
- add `standalone: true` to LazyLoadImageDirective so standalone components can import it directly
- use Helmet middleware in Express server for security headers
- apply LazyLoadImageDirective across components for optimized image loading

## Testing
- `npm test` *(fails: ng not found)*
- `npm run vercel-build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c2b708648327b6d6f6205c7d993f