### PR TITLE
Improve cart and menu UX

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,15 +1,17 @@
-import { ApplicationConfig, provideZoneChangeDetection } from '@angular/core';
+import { ApplicationConfig, provideZoneChangeDetection, importProvidersFrom } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideHttpClient,withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async'; // 👈 este es el nuevo import
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { authInterceptor } from './services/auth.interceptor';
 
 
 
 export const appConfig: ApplicationConfig = {
   providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideClientHydration(), 
-     provideHttpClient(withInterceptors([authInterceptor])), provideAnimationsAsync()]
+     provideHttpClient(withInterceptors([authInterceptor])), provideAnimationsAsync(),
+     importProvidersFrom(MatSnackBarModule)]
 };

--- a/src/app/components/drawer-menu/drawer-menu.component.html
+++ b/src/app/components/drawer-menu/drawer-menu.component.html
@@ -9,46 +9,47 @@
   <nav class="drawer-links">
     <a routerLink="/home" (click)="close()">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M3 9L12 2L21 9V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V9Z" stroke="#FFEEAD" stroke-width="2"/>
-        <path d="M9 21V12H15V21" stroke="#FFEEAD" stroke-width="2"/>
+        <path d="M3 9L12 2L21 9V20C21 20.55 20.55 21 20 21H4C3.45 21 3 20.55 3 20V9Z" stroke="#FFAD60" stroke-width="2"/>
+        <path d="M9 21V12H15V21" stroke="#FFAD60" stroke-width="2"/>
       </svg>
       Inicio
     </a>
     <a routerLink="/cuentos" (click)="close()">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M4 4H20V20L12 16L4 20V4Z" stroke="#FFEEAD" stroke-width="2"/>
+        <path d="M4 4H20V20L12 16L4 20V4Z" stroke="#FFAD60" stroke-width="2"/>
       </svg>
       Cuentos
     </a>
     <a routerLink="/pedidos" (click)="close()">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M6 9V20H18V9" stroke="#FFEEAD" stroke-width="2"/>
-        <path d="M3 5H21V9H3V5Z" stroke="#FFEEAD" stroke-width="2"/>
+        <path d="M6 9V20H18V9" stroke="#FFAD60" stroke-width="2"/>
+        <path d="M3 5H21V9H3V5Z" stroke="#FFAD60" stroke-width="2"/>
       </svg>
       Pedidos
     </a> 
     <a routerLink="/login" (click)="close()" *ngIf="!user">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M10 17L15 12L10 7" stroke="#FFEEAD" stroke-width="2"/>
-        <path d="M4 12H15" stroke="#FFEEAD" stroke-width="2"/>
+        <path d="M10 17L15 12L10 7" stroke="#FFAD60" stroke-width="2"/>
+        <path d="M4 12H15" stroke="#FFAD60" stroke-width="2"/>
       </svg>
       Login
     </a>
     <a routerLink="/admin/dashboard" (click)="close()" *ngIf="user?.role === 'ADMIN'">
       <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M4 4H10V10H4V4Z" stroke="#FFEEAD" stroke-width="2"/>
-        <path d="M14 4H20V10H14V4Z" stroke="#FFEEAD" stroke-width="2"/>
-        <path d="M4 14H10V20H4V14Z" stroke="#FFEEAD" stroke-width="2"/>
-        <path d="M14 14H20V20H14V14Z" stroke="#FFEEAD" stroke-width="2"/>
+        <path d="M4 4H10V10H4V4Z" stroke="#FFAD60" stroke-width="2"/>
+        <path d="M14 4H20V10H14V4Z" stroke="#FFAD60" stroke-width="2"/>
+        <path d="M4 14H10V20H4V14Z" stroke="#FFAD60" stroke-width="2"/>
+        <path d="M14 14H20V20H14V14Z" stroke="#FFAD60" stroke-width="2"/>
       </svg>
       Admin
     </a>
+    <button class="logout-btn" *ngIf="user" (click)="logout()">Cerrar sesión</button>
   </nav>
   <button class="cart-button" routerLink="/checkout" (click)="close()">
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <path d="M6 6H21L20 12H7" stroke="#4a2d0b" stroke-width="2"/>
-      <circle cx="9" cy="20" r="1" stroke="#4a2d0b" stroke-width="2"/>
-      <circle cx="17" cy="20" r="1" stroke="#4a2d0b" stroke-width="2"/>
+      <path d="M6 6H21L20 12H7" stroke="#A66E38" stroke-width="2"/>
+      <circle cx="9" cy="20" r="1" stroke="#A66E38" stroke-width="2"/>
+      <circle cx="17" cy="20" r="1" stroke="#A66E38" stroke-width="2"/>
     </svg>
     <span class="badge" *ngIf="itemCount > 0">{{ itemCount }}</span>
   </button>

--- a/src/app/components/drawer-menu/drawer-menu.component.scss
+++ b/src/app/components/drawer-menu/drawer-menu.component.scss
@@ -49,6 +49,7 @@
   flex-direction: column;
   padding: 1rem;
   flex: 1;
+  overflow-y: auto;
 
   a {
     display: flex;
@@ -62,6 +63,16 @@
     svg {
       flex-shrink: 0;
     }
+  }
+
+  .logout-btn {
+    margin-top: auto;
+    background: none;
+    border: 1px solid #fff;
+    color: #fff;
+    padding: 0.5rem 1rem;
+    border-radius: 4px;
+    cursor: pointer;
   }
 }
 

--- a/src/app/components/drawer-menu/drawer-menu.component.ts
+++ b/src/app/components/drawer-menu/drawer-menu.component.ts
@@ -32,4 +32,9 @@ export class DrawerMenuComponent {
   get itemCount(): number {
     return this.cart.obtenerItems().reduce((total: number, item: { cuento: any; cantidad: number }) => total + item.cantidad, 0);
   }
+
+  logout() {
+    this.auth.cerrarSesion();
+    this.close();
+  }
 }

--- a/src/app/components/mini-cart/mini-cart.component.html
+++ b/src/app/components/mini-cart/mini-cart.component.html
@@ -1,4 +1,4 @@
-<button class="floating-cart" (click)="openCart()" aria-label="Ver carrito" [attr.aria-live]="'polite'">
+<button class="floating-cart" *ngIf="!(drawer.isOpen$ | async)" (click)="openCart()" aria-label="Ver carrito" [attr.aria-live]="'polite'">
   🛒
   <span class="badge" *ngIf="totalQuantity > 0">{{ totalQuantity }}</span>
 </button>

--- a/src/app/components/mini-cart/mini-cart.component.ts
+++ b/src/app/components/mini-cart/mini-cart.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { CartService } from '../../services/carrito.service';
 import { Cuento } from '../../model/cuento.model';
+import { DrawerService } from '../../services/drawer.service';
 
 @Component({
   selector: 'app-mini-cart',
@@ -15,7 +16,11 @@ export class MiniCartComponent implements OnInit {
   open = false;
   items: { cuento: Cuento; cantidad: number }[] = [];
 
-  constructor(private cart: CartService, private router: Router) {}
+  constructor(
+    private cart: CartService,
+    private router: Router,
+    public drawer: DrawerService
+  ) {}
 
   ngOnInit(): void {
     this.cart.items$.subscribe(items => (this.items = items));

--- a/src/app/components/navbar/navbar.component.scss
+++ b/src/app/components/navbar/navbar.component.scss
@@ -136,7 +136,7 @@
   display: block;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 992px) {
   .nav-links {
     display: none;
   }

--- a/src/app/services/carrito.service.ts
+++ b/src/app/services/carrito.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { Cuento } from '../model/cuento.model';
+import { ToastService } from './toast.service';
 
 
 @Injectable({
@@ -13,7 +14,7 @@ export class CartService {
   items$ = this.itemsSubject.asObservable();
 
 
-  constructor() {
+  constructor(private toast: ToastService) {
     if (typeof window !== 'undefined' && typeof localStorage !== 'undefined') {
       const carritoGuardado = localStorage.getItem('carrito');
       if (carritoGuardado) {
@@ -35,6 +36,7 @@ export class CartService {
       this.items.push({ cuento, cantidad: 1 });
     }
     this.actualizarCarrito();
+    this.toast.show(`"${cuento.titulo}" agregado al carrito`);
   }
 
   actualizarCarrito(): void {

--- a/src/app/services/toast.service.ts
+++ b/src/app/services/toast.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Injectable({ providedIn: 'root' })
+export class ToastService {
+  constructor(private snackBar: MatSnackBar) {}
+
+  show(message: string) {
+    this.snackBar.open(message, 'Cerrar', { duration: 2000 });
+  }
+}


### PR DESCRIPTION
## Summary
- provide MatSnackBar globally
- add toast service and show message when adding to cart
- hide floating cart when drawer menu is open
- add logout button to drawer menu and style it
- make drawer menu scrollable and recolor icons
- adjust navbar mobile breakpoint

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865a3c62e1c83278ca188d684d8d3f8