### PR TITLE
Use env base URL for MP redirect

### DIFF
--- a/src/app/components/pages/pago/pago.component.spec.ts
+++ b/src/app/components/pages/pago/pago.component.spec.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute, convertToParamMap, ParamMap } from '@angular/router';
 import { of, Subject, throwError } from 'rxjs';
 import { CommonModule } from '@angular/common'; // PagoComponent is standalone, but good for TestBed consistency if it weren't
 import { RouterTestingModule } from '@angular/router/testing';
+import { environment } from '../../../../../environments/environment';
 
 import { PagoComponent } from './pago.component';
 import { PagoService } from '../../../../services/pago.service';
@@ -179,7 +180,7 @@ describe('pagarConMercadoPagoConfirmado', () => {
 
       component.pagarConMercadoPagoConfirmado();
       // @ts-ignore
-      expect(window.location.href).toBe('http://localhost:8080/api/mercado-pago/pagar/5');
+      expect(window.location.href).toBe(`${environment.apiBaseUrl}/mercado-pago/pagar/5`);
     });
   });
   

--- a/src/app/components/pages/pago/pago.component.ts
+++ b/src/app/components/pages/pago/pago.component.ts
@@ -3,6 +3,7 @@ import { RouterModule, ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { PedidoService } from '../../../services/pedido.service';
 import { PagoService } from '../../../services/pago.service'; // Added PagoService import
+import { environment } from '../../../../environments/environment';
 
 @Component({
   selector: 'app-pago',
@@ -92,7 +93,7 @@ export class PagoComponent implements OnInit {
 
 
   pagarConMercadoPagoConfirmado(): void {
-    window.location.href = `http://localhost:8080/api/mercado-pago/pagar/${this.pedidoId}`;
+    window.location.href = `${environment.apiBaseUrl}/mercado-pago/pagar/${this.pedidoId}`;
   }
 
   openMercadoPagoModal(): void {


### PR DESCRIPTION
## Summary
- inject `environment` in PagoComponent
- build Mercado Pago payment URL from `environment.apiBaseUrl`
- update unit test to expect env-based URL

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865af4f92f483279d8e6c8e56faf0b7