### PR TITLE
Validate phone digits in checkout form

### DIFF
--- a/src/app/components/pages/checkout/checkout.component.html
+++ b/src/app/components/pages/checkout/checkout.component.html
@@ -19,6 +19,9 @@
         Teléfono:
         <input formControlName="telefono" type="tel" maxlength="9" pattern="[0-9]*" required />
       </label>
+      <div class="error-mensaje" *ngIf="checkoutForm.get('telefono')?.touched && checkoutForm.get('telefono')?.errors?.['pattern']">
+        El teléfono debe tener 9 dígitos
+      </div>
   
       <div class="resumen-carrito">
         <h3>Resumen del carrito</h3>

--- a/src/app/components/pages/checkout/checkout.component.scss
+++ b/src/app/components/pages/checkout/checkout.component.scss
@@ -80,3 +80,8 @@
   max-width: 180px;
   margin-bottom: 16px;
 }
+
+.error-mensaje {
+  color: #e74c3c;
+  font-size: 0.875rem;
+}

--- a/src/app/components/pages/checkout/checkout.component.ts
+++ b/src/app/components/pages/checkout/checkout.component.ts
@@ -49,7 +49,7 @@ export class CheckoutComponent implements OnInit {
       nombre: ['', Validators.required],
       correo: ['', [Validators.required, Validators.email]],
       direccion: ['', Validators.required],
-      telefono: ['', Validators.required]
+      telefono: ['', [Validators.required, Validators.pattern(/^\d{9}$/)]]
     });
 
       // 2. Obtiene usuario logueado


### PR DESCRIPTION
## Summary
- enforce 9-digit phone number pattern in `CheckoutComponent`
- show validation feedback for wrong phone length
- style error message in checkout page

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: 403 Forbidden - GET https://registry.npmjs.org/ng)*

------
https://chatgpt.com/codex/tasks/task_e_6865af29ed988327b8ee29d6e582a49f