### PR TITLE
Show toast messages instead of alerts

### DIFF
--- a/src/app/components/pages/checkout/checkout.component.spec.ts
+++ b/src/app/components/pages/checkout/checkout.component.spec.ts
@@ -1,16 +1,20 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CheckoutComponent } from './checkout.component';
+import { ToastService } from '../../../services/toast.service';
 
 describe('CheckoutComponent', () => {
   let component: CheckoutComponent;
   let fixture: ComponentFixture<CheckoutComponent>;
+  let toastSpy: jasmine.SpyObj<ToastService>;
 
   beforeEach(async () => {
+    toastSpy = jasmine.createSpyObj('ToastService', ['show']);
     await TestBed.configureTestingModule({
-      imports: [CheckoutComponent]
+      imports: [CheckoutComponent],
+      providers: [{ provide: ToastService, useValue: toastSpy }]
     })
-    .compileComponents();
+      .compileComponents();
 
     fixture = TestBed.createComponent(CheckoutComponent);
     component = fixture.componentInstance;

--- a/src/app/components/pages/checkout/checkout.component.ts
+++ b/src/app/components/pages/checkout/checkout.component.ts
@@ -6,6 +6,7 @@ import { PedidoService } from '../../../services/pedido.service';
 import { AuthService} from '../../../services/auth.service';
 import { Pedido, PedidoItem } from '../../../model/pedido.model';
 import { User } from '../../../model/user.model';
+import { ToastService } from '../../../services/toast.service';
 import { Router } from '@angular/router';
 
 
@@ -30,6 +31,7 @@ export class CheckoutComponent implements OnInit {
     private pedidoService: PedidoService,
     private authService: AuthService,
     private router: Router,
+    private toast: ToastService,
 
   ) {
     this.user = this.authService.getUser();
@@ -108,7 +110,7 @@ export class CheckoutComponent implements OnInit {
       },
       error: (err) => {
         console.error('Error al registrar pedido:', err);
-        alert('Ocurrió un error al registrar el pedido');
+        this.toast.show('Ocurrió un error al registrar el pedido');
       }
     });
   }

--- a/src/app/components/pages/order-detail/order-detail.component.spec.ts
+++ b/src/app/components/pages/order-detail/order-detail.component.spec.ts
@@ -7,6 +7,7 @@ import { OrderDetailComponent } from './order-detail.component';
 import { PedidoService } from '../../../services/pedido.service';
 import { Pedido, PedidoItem } from '../../../model/pedido.model';
 import { CommonModule } from '@angular/common'; // For pipes
+import { ToastService } from '../../../services/toast.service';
 
 describe('OrderDetailComponent', () => {
   let component: OrderDetailComponent;
@@ -14,6 +15,7 @@ describe('OrderDetailComponent', () => {
   let mockPedidoService: jasmine.SpyObj<PedidoService>;
   let mockRouter: jasmine.SpyObj<Router>;
   let mockActivatedRoute: any; // Using 'any' for simplicity in setting snapshot
+  let toastSpy: jasmine.SpyObj<ToastService>;
 
   const mockPedidoId = 1;
   const mockPedidoData: Pedido = {
@@ -41,6 +43,7 @@ describe('OrderDetailComponent', () => {
         paramMap: convertToParamMap({ id: mockPedidoId.toString() })
       }
     };
+    toastSpy = jasmine.createSpyObj('ToastService', ['show']);
 
     await TestBed.configureTestingModule({
       declarations: [OrderDetailComponent],
@@ -51,7 +54,8 @@ describe('OrderDetailComponent', () => {
       providers: [
         { provide: PedidoService, useValue: mockPedidoService },
         { provide: Router, useValue: mockRouter },
-        { provide: ActivatedRoute, useValue: mockActivatedRoute }
+        { provide: ActivatedRoute, useValue: mockActivatedRoute },
+        { provide: ToastService, useValue: toastSpy }
       ]
     }).compileComponents();
 
@@ -109,13 +113,12 @@ describe('OrderDetailComponent', () => {
   });
 
   describe('pagarAhora', () => {
-    it('should log a message and show an alert', () => {
+    it('should log a message and show a toast', () => {
       spyOn(console, 'log');
-      spyOn(window, 'alert');
       component.pedido = mockPedidoData; // Ensure pedido is set
       component.pagarAhora();
       expect(console.log).toHaveBeenCalledWith('Intento de pago para el pedido:', mockPedidoData.id);
-      expect(window.alert).toHaveBeenCalledWith('Funcionalidad de pago aún no implementada. Serás redirigido a una página de simulación.');
+      expect(toastSpy.show).toHaveBeenCalledWith('Funcionalidad de pago aún no implementada. Serás redirigido a una página de simulación.');
     });
   });
   

--- a/src/app/components/pages/order-detail/order-detail.component.ts
+++ b/src/app/components/pages/order-detail/order-detail.component.ts
@@ -4,6 +4,7 @@ import { Pedido, PedidoItem } from '../../../model/pedido.model';
 import { PedidoService } from '../../../services/pedido.service';
 import { CommonModule } from '@angular/common'; // Import CommonModule
 import { LazyLoadImageDirective } from '../../../directives/lazy-load-image.directive';
+import { ToastService } from '../../../services/toast.service';
 
 @Component({
   selector: 'app-order-detail',
@@ -20,7 +21,8 @@ export class OrderDetailComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-    private pedidoService: PedidoService
+    private pedidoService: PedidoService,
+    private toast: ToastService
   ) {}
 
   ngOnInit(): void {
@@ -58,7 +60,7 @@ export class OrderDetailComponent implements OnInit {
     if (this.pedido) {
       // Ejemplo: Redirigir a una ruta de pago simulada o real
       // this.router.navigate(['/pago', this.pedido.id]);
-      alert('Funcionalidad de pago aún no implementada. Serás redirigido a una página de simulación.');
+      this.toast.show('Funcionalidad de pago aún no implementada. Serás redirigido a una página de simulación.');
     }
   }
 


### PR DESCRIPTION
## Summary
- display toast notifications in checkout and order detail pages
- inject ToastService in components and update tests accordingly

## Testing
- `npm test --silent` *(fails: ng not found)*
- `./node_modules/.bin/ng test --watch=false --browsers=ChromeHeadless` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865af55323083278d9b0650b9f5bd7d