### PR TITLE
Fix checkout empty cart handling

### DIFF
--- a/src/app/components/pages/checkout/checkout.component.spec.ts
+++ b/src/app/components/pages/checkout/checkout.component.spec.ts
@@ -1,23 +1,60 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 
 import { CheckoutComponent } from './checkout.component';
+import { CartService } from '../../../services/carrito.service';
+import { PedidoService } from '../../../services/pedido.service';
+import { AuthService } from '../../../services/auth.service';
+import { ToastService } from '../../../services/toast.service';
 
 describe('CheckoutComponent', () => {
   let component: CheckoutComponent;
   let fixture: ComponentFixture<CheckoutComponent>;
+  let cartServiceSpy: jasmine.SpyObj<CartService>;
+  let pedidoServiceSpy: jasmine.SpyObj<PedidoService>;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let toastServiceSpy: jasmine.SpyObj<ToastService>;
 
   beforeEach(async () => {
+    cartServiceSpy = jasmine.createSpyObj('CartService', ['obtenerItems', 'clearCart']);
+    pedidoServiceSpy = jasmine.createSpyObj('PedidoService', ['registrarPedido']);
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['getUser']);
+    toastServiceSpy = jasmine.createSpyObj('ToastService', ['show']);
+
     await TestBed.configureTestingModule({
-      imports: [CheckoutComponent]
-    })
-    .compileComponents();
+      imports: [CheckoutComponent, RouterTestingModule],
+      providers: [
+        { provide: CartService, useValue: cartServiceSpy },
+        { provide: PedidoService, useValue: pedidoServiceSpy },
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: ToastService, useValue: toastServiceSpy }
+      ]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(CheckoutComponent);
     component = fixture.componentInstance;
+    authServiceSpy.getUser.and.returnValue(null);
+    cartServiceSpy.obtenerItems.and.returnValue([]);
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should not call servicio when cart is empty', () => {
+    component.checkoutForm.setValue({
+      nombre: 'John Doe',
+      correo: 'john@example.com',
+      direccion: 'Calle 1',
+      telefono: '123456789'
+    });
+
+    component.itemsCarrito = [];
+    component.registrarPedido();
+
+    expect(toastServiceSpy.show).toHaveBeenCalled();
+    expect(pedidoServiceSpy.registrarPedido).not.toHaveBeenCalled();
   });
 });

--- a/src/app/components/pages/checkout/checkout.component.ts
+++ b/src/app/components/pages/checkout/checkout.component.ts
@@ -3,7 +3,8 @@ import { CommonModule } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { CartService } from '../../../services/carrito.service';
 import { PedidoService } from '../../../services/pedido.service';
-import { AuthService} from '../../../services/auth.service';
+import { AuthService } from '../../../services/auth.service';
+import { ToastService } from '../../../services/toast.service';
 import { Pedido, PedidoItem } from '../../../model/pedido.model';
 import { User } from '../../../model/user.model';
 import { Router } from '@angular/router';
@@ -30,6 +31,7 @@ export class CheckoutComponent implements OnInit {
     private pedidoService: PedidoService,
     private authService: AuthService,
     private router: Router,
+    private toast: ToastService,
 
   ) {
     this.user = this.authService.getUser();
@@ -74,7 +76,12 @@ export class CheckoutComponent implements OnInit {
 
   registrarPedido(): void {
     if (this.checkoutForm.invalid) return;
-  
+
+    if (this.itemsCarrito.length === 0) {
+      this.toast.show('Tu carrito est\u00e1 vac\u00edo');
+      return;
+    }
+
     const formData = this.checkoutForm.value;
   
     const pedido: Pedido = {


### PR DESCRIPTION
## Summary
- show a toast when trying to create an order with an empty cart
- prevent service call if cart has no items
- add unit test for empty cart check

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865af643bdc8327b27c66fe91c30685