### PR TITLE
Fix duplicate import causing build error

### DIFF
--- a/src/app/components/pages/checkout/checkout.component.ts
+++ b/src/app/components/pages/checkout/checkout.component.ts
@@ -7,7 +7,6 @@ import { AuthService } from '../../../services/auth.service';
 import { ToastService } from '../../../services/toast.service';
 import { Pedido, PedidoItem } from '../../../model/pedido.model';
 import { User } from '../../../model/user.model';
-import { ToastService } from '../../../services/toast.service';
 import { Router } from '@angular/router';
 
 


### PR DESCRIPTION
## Summary
- remove extra `ToastService` import in checkout component

## Testing
- `npm run test --if-present` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865b5ebb3348327a26d36468e979eae