### PR TITLE
Visual redesign of order cards

### DIFF
--- a/src/app/components/layout/layout.component.html
+++ b/src/app/components/layout/layout.component.html
@@ -5,5 +5,5 @@
 </main>
 
 <app-drawer-menu></app-drawer-menu>
-<app-mini-cart></app-mini-cart>
+<app-mini-cart *ngIf="!['/checkout','/pedidos','/perfil'].includes(router.url)"></app-mini-cart>
 

--- a/src/app/components/layout/layout.component.ts
+++ b/src/app/components/layout/layout.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterOutlet, Router } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { NavbarComponent } from '../navbar/navbar.component';
 import { DrawerMenuComponent } from '../drawer-menu/drawer-menu.component';
@@ -14,5 +14,5 @@ import { MiniCartComponent } from '../mini-cart/mini-cart.component';
   styleUrls: ['./layout.component.scss']
 })
 export class LayoutComponent {
-  constructor(public drawer: DrawerService) {}
+  constructor(public drawer: DrawerService, public router: Router) {}
 }

--- a/src/app/components/pages/order-list/order-list.component.html
+++ b/src/app/components/pages/order-list/order-list.component.html
@@ -18,7 +18,9 @@
   </div>
 
   <div *ngIf="!isLoading && !errorMensaje && pedidos.length > 0" class="filter-bar">
-    <input type="text" placeholder="Buscar n.º pedido" [(ngModel)]="searchTerm" />
+    <div class="search-input">
+      <input type="text" placeholder="Buscar n.º pedido" [(ngModel)]="searchTerm" />
+    </div>
     <select [(ngModel)]="estadoFilter">
       <option value="">Todos</option>
       <option *ngFor="let est of estadosUnicos" [value]="est">{{ est }}</option>
@@ -26,23 +28,40 @@
     <button type="button" class="btn-export" (click)="exportCSV()">Exportar CSV</button>
   </div>
 
-  <div *ngIf="!isLoading && !errorMensaje && filteredPedidos.length > 0" class="orders-grid" role="region">
-    <article *ngFor="let pedido of paginatedPedidos; trackBy: trackByPedidoId" class="order-row order-card" role="region" tabindex="0" [attr.aria-labelledby]="'order-' + getPedidoId(pedido)" [@fadeSlideIn]>
-      <div class="detail-column">
-        <h2 id="order-{{getPedidoId(pedido)}}"><span class="material-icons book-icon">menu_book</span>Pedido #{{ getPedidoId(pedido) }}</h2>
-        <p><strong>Fecha:</strong> {{ pedido.fecha | date:'dd/MM/yyyy' }}</p>
-        <p><strong>Estado:</strong>
-          <span class="status" [ngClass]="'status-' + pedido.estado.toLowerCase().replace(' ', '-')">{{ pedido.estado }}</span>
-        </p>
-        <p><strong>Total:</strong> {{ pedido.total | currency:'USD':'symbol':'1.2-2' }}</p>
-        <button *ngIf="pedido.estado === 'PAGADO'; else pagoBoton" class="btn-detail" (click)="verDetalle(getPedidoId(pedido))" [attr.aria-label]="'Ver detalle del pedido ' + getPedidoId(pedido)">Ver detalle</button>
-        <ng-template #pagoBoton>
-          <button class="btn-pay" (click)="irAPago(getPedidoId(pedido))" [attr.aria-label]="'Pagar pedido ' + getPedidoId(pedido)">Pagar</button>
-        </ng-template>
-        <button class="btn-pdf" (click)="descargarPDF(getPedidoId(pedido))">Descargar PDF</button>
-        <button *ngIf="pedido.estado === 'ENTREGADO'" class="btn btn-outline" (click)="dejarResena(getPedidoId(pedido))">Valorar</button>
-      </div>
-    </article>
+  <p class="result-count" *ngIf="filteredPedidos.length > 0">
+    Mostrando {{ filteredPedidos.length }} pedidos
+    <ng-container *ngIf="estadoFilter">con estado '{{ getEstadoVisible(estadoFilter) }}'</ng-container>
+  </p>
+
+    <div *ngIf="!isLoading && !errorMensaje && filteredPedidos.length > 0" class="orders-grid" role="region">
+      <article *ngFor="let pedido of paginatedPedidos; trackBy: trackByPedidoId" class="order-row order-card" role="region" tabindex="0" [attr.aria-labelledby]="'order-' + getPedidoId(pedido)" [@fadeSlideIn]>
+        <div class="detail-column">
+          <div class="card-header">
+            <h3 id="order-{{getPedidoId(pedido)}}">📚 Pedido #{{ getPedidoId(pedido) }}</h3>
+            <span class="date">🗓️ {{ pedido.fecha | date:'dd/MM/yyyy' }}</span>
+          </div>
+          <p class="estado" [ngClass]="getEstadoClass(pedido.estado)">{{ getEstadoVisible(pedido.estado) }}</p>
+          <p class="total"><strong>Total:</strong> {{ pedido.total | currency:'USD':'symbol':'1.2-2' }}</p>
+          <div class="productos">
+            <ul>
+              <li *ngFor="let item of pedido.items.slice(0, itemsExpanded[getPedidoId(pedido)] ? pedido.items.length : 2)">
+                {{ item.nombreCuento }} x{{ item.cantidad }}
+              </li>
+            </ul>
+            <button *ngIf="pedido.items.length > 2 && !itemsExpanded[getPedidoId(pedido)]" class="ver-mas" (click)="toggleItems(getPedidoId(pedido))">Ver más</button>
+          </div>
+          <div class="acciones">
+            <ng-container *ngIf="pedido.estado === 'PAGADO'; else pagarAhora">
+              <button class="btn-primary" (click)="verDetalle(getPedidoId(pedido))">Ver detalle</button>
+            </ng-container>
+            <ng-template #pagarAhora>
+              <button class="btn-primary" (click)="irAPago(getPedidoId(pedido))">Pagar ahora</button>
+            </ng-template>
+            <button class="btn-secondary" (click)="descargarPDF(getPedidoId(pedido))">Descargar PDF</button>
+            <button *ngIf="pedido.estado === 'ENTREGADO'" class="btn-secondary" (click)="dejarResena(getPedidoId(pedido))">Valorar</button>
+          </div>
+        </div>
+      </article>
     <div class="pagination" *ngIf="totalPages > 1">
       <button class="btn" (click)="changePage(-1)" [disabled]="currentPage === 1">Anterior</button>
       <span>{{currentPage}} / {{totalPages}}</span>

--- a/src/app/components/pages/order-list/order-list.component.scss
+++ b/src/app/components/pages/order-list/order-list.component.scss
@@ -47,20 +47,58 @@
     }
   }
 
+  .btn-primary {
+    background-color: #A66E38;
+    color: #fff;
+    padding: 0.5rem 1rem;
+    font-weight: bold;
+    border-radius: 12px;
+  }
+
+  .btn-secondary {
+    background-color: #f0e5d8;
+    color: #333;
+    border: 1px solid #ccc;
+    padding: 0.5rem 1rem;
+    border-radius: 12px;
+  }
+
   .filter-bar {
     display: flex;
     flex-wrap: wrap;
     gap: 1rem;
     justify-content: center;
     margin-bottom: 1rem;
-    input, select {
-      padding: 0.5rem;
-      border-radius: 4px;
-      border: 1px solid var(--grey-light);
+
+    .search-input {
+      position: relative;
+      &::before {
+        content: '🔍';
+        position: absolute;
+        left: 8px;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+      input {
+        padding-left: 2rem;
+      }
     }
+
+    select {
+      padding: 0.5rem;
+      border-radius: 12px;
+      border: 1px solid var(--grey-light);
+      background-color: #FFEEAD;
+    }
+
     .export-btn {
       padding: 0.5rem 1rem;
     }
+  }
+
+  .result-count {
+    text-align: center;
+    margin-bottom: 1rem;
   }
 
   .orders-grid {
@@ -71,8 +109,7 @@
 
   .order-row,
   .order-card {
-    display: grid;
-    grid-template-columns: 2fr 1fr;
+    display: block;
     gap: 1rem;
     background: #fff url('/assets/libros_killa.png') no-repeat right bottom/80px;
     border-radius: 8px;
@@ -96,10 +133,22 @@
     }
 
     .detail-column {
-      h2 {
-        color: var(--primary-color);
-        font-size: 1.5rem;
+      .card-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
         margin-bottom: 0.5rem;
+
+        h3 {
+          color: var(--primary-color);
+          font-size: 1.3rem;
+          margin: 0;
+        }
+
+        .date {
+          font-size: 0.9rem;
+          color: var(--text-color-light);
+        }
       }
 
       p {
@@ -112,35 +161,6 @@
         }
       }
 
-      .btn-detail {
-        background: #FFEAD9;
-        color: #A66E38;
-        border: none;
-        padding: 0.5rem 1rem;
-        border-radius: 4px;
-        cursor: pointer;
-        margin-right: 0.5rem;
-      }
-
-      .btn-pay {
-        background: #A66E38;
-        color: #fff;
-        border: none;
-        padding: 0.5rem 1rem;
-        border-radius: 4px;
-        cursor: pointer;
-        margin-right: 0.5rem;
-      }
-
-      .btn-pdf {
-        background: #FFEAD9;
-        color: #A66E38;
-        border: none;
-        padding: 0.5rem 1rem;
-        border-radius: 4px;
-        cursor: pointer;
-        margin-right: 0.5rem;
-      }
 
       .btn-export {
         border: 1px solid #A66E38;
@@ -150,6 +170,27 @@
         background: transparent;
         cursor: pointer;
       }
+
+      .acciones {
+        margin-top: 0.5rem;
+        display: flex;
+        gap: 0.5rem;
+      }
+
+      .estado {
+        font-weight: bold;
+        padding: 0.25rem 0.5rem;
+        border-radius: 8px;
+        color: #fff;
+        display: inline-block;
+        margin-bottom: 0.5rem;
+      }
+
+      .status-pago-pendiente { background-color: #FFAD60; }
+      .status-pago-enviado { background-color: #96CEB4; }
+      .status-pago-verificado { background-color: #4CAF50; }
+      .status-enviado { background-color: #42A5F5; }
+      .status-entregado { background-color: #2E7D32; }
     }
   }
 }
@@ -215,9 +256,8 @@
     width: 100%;
   }
 
-  .btn-detail,
-  .btn-pay,
-  .btn-pdf,
+  .btn-primary,
+  .btn-secondary,
   .btn-export {
     font-size: 14px;
   }

--- a/src/app/components/pages/order-list/order-list.component.spec.ts
+++ b/src/app/components/pages/order-list/order-list.component.spec.ts
@@ -132,31 +132,31 @@ describe('OrderListComponent', () => {
       expect(orderRows.length).toBe(2);
 
       const firstRow = orderRows[0];
-      expect(firstRow.query(By.css('.detail-column h2')).nativeElement.textContent).toContain(`Pedido #${mockPedidosData[0].id}`);
-      
-      // Use DatePipe for formatting date as in component
+      expect(firstRow.query(By.css('.card-header h3')).nativeElement.textContent).toContain(`Pedido #${mockPedidosData[0].id}`);
+
       const datePipe = new DatePipe('en-US');
       const expectedDate = datePipe.transform(mockPedidosData[0].fecha, 'dd/MM/yyyy');
-      expect(firstRow.nativeElement.textContent).toContain(`Fecha: ${expectedDate}`);
+      expect(firstRow.query(By.css('.date')).nativeElement.textContent).toContain(expectedDate);
 
-      expect(firstRow.nativeElement.textContent).toContain(`Estado: ${mockPedidosData[0].estado}`);
-      
+      const expectedEstado = component.getEstadoVisible(mockPedidosData[0].estado);
+      expect(firstRow.query(By.css('.estado')).nativeElement.textContent).toContain(expectedEstado);
+
       // Use CurrencyPipe for formatting total as in component
       const currencyPipe = new CurrencyPipe('en-US', 'USD'); // Adjust locale and currency code as needed
       const expectedTotal = currencyPipe.transform(mockPedidosData[0].total, 'USD', 'symbol', '1.2-2');
       expect(firstRow.nativeElement.textContent).toContain(`Total: ${expectedTotal}`);
     }));
 
-    it('should call verDetalle when detail button is clicked', fakeAsync(() => {
-      spyOn(component, 'verDetalle');
+    it('should call irAPago when primary action button is clicked', fakeAsync(() => {
+      spyOn(component, 'irAPago');
       mockPedidoService.getOrders.and.returnValue(of(mockPedidosData));
       component.ngOnInit();
       tick();
       fixture.detectChanges();
 
-      const detailBtn = fixture.debugElement.query(By.css('.detail-column .btn-detail'));
-      detailBtn.triggerEventHandler('click', null);
-      expect(component.verDetalle).toHaveBeenCalledWith(mockPedidosData[0].id);
+      const payBtn = fixture.debugElement.query(By.css('.acciones .btn-primary'));
+      payBtn.triggerEventHandler('click', null);
+      expect(component.irAPago).toHaveBeenCalledWith(mockPedidosData[0].id);
     }));
   });
 });

--- a/src/app/components/pages/order-list/order-list.component.ts
+++ b/src/app/components/pages/order-list/order-list.component.ts
@@ -33,6 +33,15 @@ export class OrderListComponent implements OnInit {
   estadosUnicos: string[] = [];
   currentPage: number = 1;
   itemsPerPage: number = 5;
+  itemsExpanded: { [id: number]: boolean } = {};
+
+  estadoMap: Record<string, { texto: string; emoji: string }> = {
+    'PAGO_PENDIENTE': { texto: 'Pago pendiente', emoji: '🔶' },
+    'PAGO_ENVIADO': { texto: 'Pago enviado', emoji: '📤' },
+    'PAGO_VERIFICADO': { texto: 'Pago verificado', emoji: '✅' },
+    'ENVIADO': { texto: 'Enviado', emoji: '📦' },
+    'ENTREGADO': { texto: 'Entregado', emoji: '📬' },
+  };
 
   constructor(
     private pedidoService: PedidoService,
@@ -77,6 +86,19 @@ export class OrderListComponent implements OnInit {
 
   irAPago(pedidoId: number): void {
     this.router.navigate(['/pago', pedidoId]);
+  }
+
+  getEstadoVisible(estado: string): string {
+    const info = this.estadoMap[estado];
+    return info ? `${info.emoji} ${info.texto}` : estado;
+  }
+
+  getEstadoClass(estado: string): string {
+    return 'status-' + estado.toLowerCase().replace('_', '-');
+  }
+
+  toggleItems(id: number): void {
+    this.itemsExpanded[id] = !this.itemsExpanded[id];
   }
 
   getPedidoId(p: Pedido): number {

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,7 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
 <body>
   <app-root></app-root>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,7 +5,6 @@
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 // styles.scss
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap');
 
 body {
   font-family: 'Poppins', sans-serif;


### PR DESCRIPTION
## Summary
- style updates for order list cards
- show emoji/status mapping in list component
- hide mini cart on checkout, orders and profile pages
- update order list unit tests
- fix build budget by loading Poppins via link instead of CSS import

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d0f9c310832792686a660bbf2e23