### PR TITLE
Add story detail accordion and sticky cart

### DIFF
--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -21,21 +21,25 @@
       </div>
       <p class="stock">Stock: {{ cuento?.habilitado ? cuento?.stock : 'Sin stock' }}</p>
 
-      <p class="descripcion">{{ cuento?.descripcionCorta }}</p>
-
-      <div class="extra-info">
-        <p><strong>Editorial:</strong> {{ cuento?.editorial }}</p>
-        <p><strong>Tipo de Edición:</strong> {{ cuento?.tipoEdicion }}</p>
-        <p><strong>Páginas:</strong> {{ cuento?.nroPaginas }}</p>
-        <p><strong>Publicado en:</strong> {{ cuento?.fechaPublicacion | date }}</p>
-        <p><strong>Edad Recomendada:</strong> {{ cuento?.edadRecomendada }}</p>
-      </div>
+      <p class="sinopsis" [class.expand]="mostrarSinopsisCompleta">{{ cuento?.descripcionCorta }}</p>
+      <button *ngIf="!mostrarSinopsisCompleta" class="leer-mas" (click)="mostrarMasSinopsis()">Leer más</button>
+      <details class="accordion">
+        <summary>Ficha técnica</summary>
+        <ul class="content">
+          <li><strong>ISBN:</strong> {{ cuento?.isbn }}</li>
+          <li><strong>Editorial:</strong> {{ cuento?.editorial }}</li>
+          <li><strong>Publicado en:</strong> {{ cuento?.fechaPublicacion | date }}</li>
+          <li><strong>Páginas:</strong> {{ cuento?.nroPaginas }}</li>
+          <li><strong>Edad Recomendada:</strong> {{ cuento?.edadRecomendada }}</li>
+        </ul>
+      </details>
 
       <div class="acciones">
-        <button class="boton-dorado" (click)="agregarAlCarrito(); $event.stopPropagation()" [disabled]="!cuento?.habilitado">
-          Agregar al carrito
-        </button>
         <button class="boton-volver" (click)="volver(); $event.stopPropagation()">Volver</button>
       </div>
-    </div>
+  </div>
+  <div class="sticky-cta" *ngIf="cuento">
+    <span class="price">S/ {{ cuento?.precio | number:'1.2-2' }}</span>
+    <button class="boton-dorado" (click)="agregarAlCarrito(); $event.stopPropagation()" [disabled]="!cuento?.habilitado">Añadir al carrito</button>
+  </div>
 </div>

--- a/src/app/components/detalle-cuento/detalle-cuento.component.scss
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.scss
@@ -1,5 +1,5 @@
 .detalle-pagina {
-  padding: 20px;
+  padding: 20px 20px 80px;
   background: #fff8f0;
   min-height: 100vh;
   display: flex;
@@ -60,15 +60,60 @@
   color: #8d6e63;
 }
 
-.descripcion {
-  margin-bottom: 20px;
+.sinopsis {
+  margin-bottom: 10px;
   font-size: 1rem;
   color: #5d4037;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
 }
 
-.extra-info p {
-  margin: 5px 0;
-  font-size: 0.95rem;
+.sinopsis.expand {
+  -webkit-line-clamp: unset;
+}
+
+.leer-mas {
+  margin-bottom: 20px;
+  font-size: 0.875rem;
+  color: #96ceb4;
+  background: none;
+  border: none;
+  cursor: pointer;
+  text-decoration: underline;
+  align-self: flex-start;
+}
+
+
+.accordion {
+  margin-bottom: 20px;
+}
+
+.accordion summary {
+  padding: 0.5rem 1rem;
+  background: #ffad60;
+  color: #fff;
+  border-radius: 8px;
+  cursor: pointer;
+  list-style: none;
+}
+
+.accordion[open] summary {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.accordion .content {
+  padding: 1rem;
+  background: #ffffff;
+  color: #5d4037;
+  border: 1px solid #ffad60;
+  border-top: none;
+  list-style: none;
+}
+.accordion .content li {
+  margin: 2px 0;
 }
 
 .acciones {
@@ -111,6 +156,29 @@
 
 .boton-volver:hover {
   background-color: #c9a97b; /* Un poco más oscuro en hover */
+}
+
+.sticky-cta {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: #ffffff;
+  padding: 1rem;
+  box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.sticky-cta .price {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #5d4037;
+}
+
+.sticky-cta .boton-dorado {
+  width: auto;
 }
 
 /* Responsive */

--- a/src/app/components/detalle-cuento/detalle-cuento.component.ts
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.ts
@@ -15,6 +15,7 @@ import { Router } from '@angular/router';
 export class DetalleCuentoComponent implements OnInit {
   cuento?: Cuento;
   cargandoImagen: boolean = true; // 🔥 Nueva bandera para el skeleton
+  mostrarSinopsisCompleta = false;
 
   constructor(
     private route: ActivatedRoute,
@@ -45,6 +46,10 @@ export class DetalleCuentoComponent implements OnInit {
   }
   imagenCargada(): void {
     this.cargandoImagen = false; // 🔥 Cuando la imagen carga, quitamos skeleton
+  }
+
+  mostrarMasSinopsis(): void {
+    this.mostrarSinopsisCompleta = true;
   }
 
   volver() {

--- a/src/app/model/cuento.model.ts
+++ b/src/app/model/cuento.model.ts
@@ -12,5 +12,6 @@ export interface Cuento {
   stock: number;
   precio: number;
   imagenUrl: string;
+  isbn?: string;
   habilitado?: boolean; // Nuevo campo para estado de habilitación
 }


### PR DESCRIPTION
## Summary
- include ISBN property on `Cuento` model
- show short sinopsis with a *Leer más* button
- display technical info inside an accordion
- add sticky cart call-to-action banner

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866611196148327b7b53ffec3f716ba