### PR TITLE
Add related carousel and sharing options

### DIFF
--- a/public/assets/tiktok.svg
+++ b/public/assets/tiktok.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <path fill="#000" d="M30 4h6a8 8 0 0 0 8 8v6a14 14 0 0 1-8-2.6V32a14 14 0 1 1-14-14v6a8 8 0 1 0 8 8V4z"/>
+</svg>

--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -1,41 +1,72 @@
 <div class="detalle-pagina">
   <div class="detalle-grid">
     <div class="imagen-skeleton" *ngIf="cargandoImagen"></div>
-
     <!-- Imagen del cuento -->
-    <img 
-      [src]="cuento?.imagenUrl || 'assets/placeholder-cuento.jpg'" 
+    <img
+      [appLazyLoad]="cuento?.imagenUrl || 'assets/placeholder-cuento.jpg'"
       alt="Imagen del cuento"
       (error)="cargarImagenPlaceholder($event)"
       (load)="imagenCargada()"
-       style="cursor: pointer;"
+      style="cursor: pointer;"
       [class.loaded]="!cargandoImagen"
     />
+  </div>
+
+  <div class="detalle-info">
+    <h1>{{ cuento?.titulo }}</h1>
+    <div class="autor-precio">
+      <h3>Autor: {{ cuento?.autor }}</h3>
+      <span class="precio">S/ {{ cuento?.precio | number:'1.2-2' }}</span>
+    </div>
+    <div class="rating" aria-label="5 de 5">
+      <span>★★★★★</span>
+    </div>
+    <blockquote class="testimonial">
+      “Un viaje mágico para toda la familia” – Carla R.
+    </blockquote>
+    <p class="stock">Stock: {{ cuento?.habilitado ? cuento?.stock : 'Sin stock' }}</p>
+
+    <p class="descripcion">{{ cuento?.descripcionCorta }}</p>
+
+    <button class="tech-toggle" (click)="toggleTech()" aria-controls="tech-panel" [attr.aria-expanded]="openTech">Ficha técnica</button>
+    <div class="extra-info" id="tech-panel" [hidden]="!openTech">
+      <p><strong>Editorial:</strong> {{ cuento?.editorial }}</p>
+      <p><strong>Tipo de Edición:</strong> {{ cuento?.tipoEdicion }}</p>
+      <p><strong>Páginas:</strong> {{ cuento?.nroPaginas }}</p>
+      <p><strong>Publicado en:</strong> {{ cuento?.fechaPublicacion | date }}</p>
+      <p><strong>Edad Recomendada:</strong> {{ cuento?.edadRecomendada }}</p>
     </div>
 
-    <div class="detalle-info">
-      <h1>{{ cuento?.titulo }}</h1>
-      <div class="autor-precio">
-        <h3>Autor: {{ cuento?.autor }}</h3>
-        <span class="precio">S/ {{ cuento?.precio | number:'1.2-2' }}</span>
-      </div>
-      <p class="stock">Stock: {{ cuento?.habilitado ? cuento?.stock : 'Sin stock' }}</p>
-
-      <p class="descripcion">{{ cuento?.descripcionCorta }}</p>
-
-      <div class="extra-info">
-        <p><strong>Editorial:</strong> {{ cuento?.editorial }}</p>
-        <p><strong>Tipo de Edición:</strong> {{ cuento?.tipoEdicion }}</p>
-        <p><strong>Páginas:</strong> {{ cuento?.nroPaginas }}</p>
-        <p><strong>Publicado en:</strong> {{ cuento?.fechaPublicacion | date }}</p>
-        <p><strong>Edad Recomendada:</strong> {{ cuento?.edadRecomendada }}</p>
-      </div>
-
-      <div class="acciones">
-        <button class="boton-dorado" (click)="agregarAlCarrito(); $event.stopPropagation()" [disabled]="!cuento?.habilitado">
-          Agregar al carrito
+    <div class="acciones">
+      <button class="boton-dorado" (click)="agregarAlCarrito(); $event.stopPropagation()" [disabled]="!cuento?.habilitado">
+        Agregar al carrito
+      </button>
+      <button class="boton-volver" (click)="volver(); $event.stopPropagation()">Volver</button>
+      <div class="share">
+        <button aria-label="Compartir en WhatsApp" (click)="compartir('whatsapp')">
+          <img appLazyLoad="assets/whatsapp.svg" alt="WhatsApp">
         </button>
-        <button class="boton-volver" (click)="volver(); $event.stopPropagation()">Volver</button>
+        <button aria-label="Compartir en TikTok" (click)="compartir('tiktok')">
+          <img appLazyLoad="assets/tiktok.svg" alt="TikTok">
+        </button>
       </div>
     </div>
+  </div>
+
+  <section class="relacionados" *ngIf="relatedCuentos.length">
+    <h2>Te puede interesar</h2>
+    <div class="carousel-wrapper">
+      <button class="prev" aria-label="Anterior" (click)="scrollCarousel(-1)">‹</button>
+      <div class="carousel" #carousel>
+        <div class="slide" *ngFor="let book of relatedCuentos">
+          <div class="card">
+            <img appLazyLoad="{{ book.imagenUrl || 'assets/placeholder-cuento.jpg' }}" alt="{{ book.titulo }}" class="w-full rounded-lg" />
+            <p class="titulo">{{ book.titulo }}</p>
+            <p class="precio">S/ {{ book.precio | number:'1.2-2' }}</p>
+          </div>
+        </div>
+      </div>
+      <button class="next" aria-label="Siguiente" (click)="scrollCarousel(1)">›</button>
+    </div>
+  </section>
 </div>

--- a/src/app/components/detalle-cuento/detalle-cuento.component.scss
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.scss
@@ -75,6 +75,104 @@
   margin-top: 30px;
   display: flex;
   gap: 15px;
+  align-items: center;
+}
+
+.share {
+  display: flex;
+  gap: 10px;
+
+  button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    img {
+      width: 24px;
+      height: 24px;
+    }
+  }
+}
+
+.rating span {
+  color: #FFAD60;
+  font-size: 1.2rem;
+}
+
+.testimonial {
+  margin-top: 0.5rem;
+  font-style: italic;
+  color: #666;
+}
+
+.tech-toggle {
+  margin-top: 1rem;
+  background: none;
+  border: none;
+  color: #a66e38;
+  cursor: pointer;
+  text-decoration: underline;
+}
+
+.relacionados {
+  margin-top: 2rem;
+
+  h2 {
+    margin-bottom: 1rem;
+  }
+
+  .carousel-wrapper {
+    display: flex;
+    align-items: center;
+  }
+
+  .carousel {
+    display: flex;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;
+    gap: 1rem;
+    padding: 1rem 0;
+  }
+
+  .slide {
+    flex: 0 0 auto;
+    scroll-snap-align: start;
+    width: 150px;
+  }
+
+  .card {
+    background: #fff;
+    border-radius: 8px;
+    padding: 0.5rem;
+    text-align: center;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+    img {
+      width: 100%;
+      border-radius: 6px;
+      height: 120px;
+      object-fit: cover;
+    }
+
+    .titulo {
+      margin-top: 0.5rem;
+      font-size: 0.9rem;
+      color: #333;
+      font-weight: 600;
+    }
+
+    .precio {
+      color: #A66E38;
+      font-size: 0.9rem;
+    }
+  }
+
+  .prev,
+  .next {
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    cursor: pointer;
+  }
 }
 
 .boton-dorado {

--- a/src/app/components/detalle-cuento/detalle-cuento.component.ts
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { CuentoService } from './../../services/cuento.service';
 import { Cuento } from './../../model/cuento.model';
@@ -15,6 +15,9 @@ import { Router } from '@angular/router';
 export class DetalleCuentoComponent implements OnInit {
   cuento?: Cuento;
   cargandoImagen: boolean = true; // 🔥 Nueva bandera para el skeleton
+  relatedCuentos: Cuento[] = [];
+  openTech = false;
+  @ViewChild('carousel', { static: false }) carousel?: ElementRef<HTMLDivElement>;
 
   constructor(
     private route: ActivatedRoute,
@@ -29,6 +32,9 @@ export class DetalleCuentoComponent implements OnInit {
     if (id) {
       this.cuentoService.getCuentoById(+id).subscribe(data => {
         this.cuento = data;
+      });
+      this.cuentoService.obtenerCuentos().subscribe(cuentos => {
+        this.relatedCuentos = cuentos.filter(c => c.id !== +id).slice(0, 8);
       });
     }
   }
@@ -45,6 +51,27 @@ export class DetalleCuentoComponent implements OnInit {
   }
   imagenCargada(): void {
     this.cargandoImagen = false; // 🔥 Cuando la imagen carga, quitamos skeleton
+  }
+
+  toggleTech(): void {
+    this.openTech = !this.openTech;
+  }
+
+  scrollCarousel(direction: number) {
+    const container = this.carousel?.nativeElement;
+    if (container) {
+      const width = container.offsetWidth;
+      container.scrollBy({ left: width * 0.8 * direction, behavior: 'smooth' });
+    }
+  }
+
+  compartir(red: 'whatsapp' | 'tiktok') {
+    const url = encodeURIComponent(window.location.href);
+    if (red === 'whatsapp') {
+      window.open(`https://wa.me/?text=${url}`, '_blank');
+    } else {
+      window.open('https://www.tiktok.com/upload?url=' + url, '_blank');
+    }
   }
 
   volver() {

--- a/src/app/components/detalle-cuento/detalle-cuento.module.ts
+++ b/src/app/components/detalle-cuento/detalle-cuento.module.ts
@@ -2,6 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule, Routes } from '@angular/router';
 import { DetalleCuentoComponent } from './detalle-cuento.component';
+import { LazyLoadImageDirective } from '../../directives/lazy-load-image.directive';
 
 const routes: Routes = [
   { path: '', component: DetalleCuentoComponent }
@@ -11,7 +12,8 @@ const routes: Routes = [
   declarations: [DetalleCuentoComponent],
   imports: [
     CommonModule,
-    RouterModule.forChild(routes)
+    RouterModule.forChild(routes),
+    LazyLoadImageDirective
   ]
 })
 export class DetalleCuentoModule {}


### PR DESCRIPTION
## Summary
- show related cuentos in a horizontal carousel
- display rating stars and testimonial
- add share buttons with WhatsApp and TikTok
- provide accordion for technical details with ARIA attributes
- lazy load images and enable directive

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866613283f08327b1fdcf301660a262