### PR TITLE
Implement responsive admin drawer

### DIFF
--- a/src/app/components/admin-drawer/admin-drawer.component.html
+++ b/src/app/components/admin-drawer/admin-drawer.component.html
@@ -1,0 +1,9 @@
+<aside class="admin-drawer" [class.open]="isOpen">
+  <nav>
+    <a *ngFor="let item of menuItems" (click)="navigate(item)">
+      <svg [innerHTML]="item.icon"></svg>
+      <span>{{ item.label }}</span>
+    </a>
+  </nav>
+</aside>
+<div class="backdrop" *ngIf="isOpen" (click)="closed.emit()"></div>

--- a/src/app/components/admin-drawer/admin-drawer.component.scss
+++ b/src/app/components/admin-drawer/admin-drawer.component.scss
@@ -1,0 +1,49 @@
+@import '../../styles/variables';
+
+$drawer-width: 260px;
+
+.admin-drawer {
+  background: #fff;
+  border-right: 1px solid rgba($text-dark, .1);
+  width: $drawer-width;
+  height: 100vh;
+  position: sticky;
+  top: 0;
+  transform: translateX(-100%);
+  transition: transform .3s ease;
+  z-index: 1000;
+  nav {
+    display: flex;
+    flex-direction: column;
+    a {
+      display: flex;
+      align-items: center;
+      gap: .75rem;
+      padding: .75rem 1rem;
+      color: $text-dark;
+      text-decoration: none;
+      &:hover {
+        background: rgba($text-dark, .05);
+      }
+    }
+  }
+  &.open {
+    transform: translateX(0);
+    position: absolute;
+  }
+}
+
+.backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.3);
+  z-index: 900;
+}
+
+@media (min-width: 1024px) {
+  .admin-drawer {
+    transform: translateX(0);
+    position: sticky;
+  }
+  .backdrop { display:none; }
+}

--- a/src/app/components/admin-drawer/admin-drawer.component.ts
+++ b/src/app/components/admin-drawer/admin-drawer.component.ts
@@ -1,0 +1,35 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+
+interface MenuItem {
+  label: string;
+  route: string;
+  icon: string;
+}
+
+@Component({
+  selector: 'app-admin-drawer',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './admin-drawer.component.html',
+  styleUrls: ['./admin-drawer.component.scss']
+})
+export class AdminDrawerComponent {
+  @Input() isOpen = false;
+  @Output() closed = new EventEmitter<void>();
+
+  menuItems: MenuItem[] = [
+    { label: 'Dashboard', route: '/admin/dashboard', icon: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 4H10V10H4V4Z" stroke="#FFAD60" stroke-width="2"/><path d="M14 4H20V10H14V4Z" stroke="#FFAD60" stroke-width="2"/><path d="M4 14H10V20H4V14Z" stroke="#FFAD60" stroke-width="2"/><path d="M14 14H20V20H14V14Z" stroke="#FFAD60" stroke-width="2"/></svg>' },
+    { label: 'Cuentos', route: '/admin/cuentos', icon: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M4 4H20V20L12 16L4 20V4Z" stroke="#FFAD60" stroke-width="2"/></svg>' },
+    { label: 'Pedidos', route: '/admin/pedidos', icon: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M6 9V20H18V9" stroke="#FFAD60" stroke-width="2"/><path d="M3 5H21V9H3V5Z" stroke="#FFAD60" stroke-width="2"/></svg>' },
+    { label: 'Usuarios', route: '/admin/usuarios', icon: '<svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M12 12C14.7614 12 17 9.76142 17 7C17 4.23858 14.7614 2 12 2C9.23858 2 7 4.23858 7 7C7 9.76142 9.23858 12 12 12Z" stroke="#FFAD60" stroke-width="2"/><path d="M4 22C4 17.5817 7.58172 14 12 14C16.4183 14 20 17.5817 20 22" stroke="#FFAD60" stroke-width="2"/></svg>' }
+  ];
+
+  constructor(private router: Router) {}
+
+  navigate(item: MenuItem) {
+    this.router.navigate([item.route]);
+    this.closed.emit();
+  }
+}

--- a/src/app/components/drawer-menu/drawer-menu.component.html
+++ b/src/app/components/drawer-menu/drawer-menu.component.html
@@ -45,7 +45,7 @@
     </a>
     <button class="logout-btn" *ngIf="user" (click)="logout()">Cerrar sesión</button>
   </nav>
-  <button class="cart-button" routerLink="/checkout" (click)="close()">
+  <button class="cart-button" routerLink="/checkout" (click)="close()" *ngIf="user?.role === 'USER'">
     <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
       <path d="M6 6H21L20 12H7" stroke="#A66E38" stroke-width="2"/>
       <circle cx="9" cy="20" r="1" stroke="#A66E38" stroke-width="2"/>

--- a/src/app/components/layout/layout.component.html
+++ b/src/app/components/layout/layout.component.html
@@ -5,5 +5,5 @@
 </main>
 
 <app-drawer-menu></app-drawer-menu>
-<app-mini-cart *ngIf="!['/checkout','/pedidos','/perfil'].includes(router.url)"></app-mini-cart>
+<app-mini-cart *ngIf="user?.role === 'USER' && !['/checkout','/pedidos','/perfil'].includes(router.url)"></app-mini-cart>
 

--- a/src/app/components/layout/layout.component.ts
+++ b/src/app/components/layout/layout.component.ts
@@ -5,6 +5,8 @@ import { NavbarComponent } from '../navbar/navbar.component';
 import { DrawerMenuComponent } from '../drawer-menu/drawer-menu.component';
 import { DrawerService } from '../../services/drawer.service';
 import { MiniCartComponent } from '../mini-cart/mini-cart.component';
+import { AuthService } from '../../services/auth.service';
+import { User } from '../../model/user.model';
 
 @Component({
   selector: 'app-layout',
@@ -14,5 +16,9 @@ import { MiniCartComponent } from '../mini-cart/mini-cart.component';
   styleUrls: ['./layout.component.scss']
 })
 export class LayoutComponent {
-  constructor(public drawer: DrawerService, public router: Router) {}
+  user: User | null = null;
+  constructor(public drawer: DrawerService, public router: Router, private auth: AuthService) {
+    this.user = this.auth.getUser();
+    this.auth.usuarioLogueado$.subscribe(u => this.user = u);
+  }
 }

--- a/src/app/components/mini-cart/mini-cart.component.html
+++ b/src/app/components/mini-cart/mini-cart.component.html
@@ -4,7 +4,7 @@
 </button>
 
 <div class="backdrop" [class.show]="open" (click)="closeCart()"></div>
-<aside class="drawer" [class.open]="open" role="dialog" aria-modal="true">
+<aside class="drawer mini-cart" [class.open]="open" role="dialog" aria-modal="true">
   <header class="drawer-header">
     <h3 tabindex="0">Mi carrito</h3>
     <button class="close-btn" (click)="closeCart()" aria-label="Cerrar">✖</button>

--- a/src/app/components/mini-cart/mini-cart.component.scss
+++ b/src/app/components/mini-cart/mini-cart.component.scss
@@ -29,6 +29,11 @@
   }
 }
 
+.mini-cart {
+  z-index: 1000;
+  margin-bottom: 72px;
+}
+
 @media (max-width: 768px) {
   .floating-cart {
     width: 48px;

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
@@ -16,18 +16,9 @@
     </ng-container>
 
     <ng-container *ngIf="!isLoading && !errorMensaje">
-      <div class="stat-card">
-        <span class="value">{{ cuentosPublicados }}</span>
-        <span class="label">Cuentos publicados</span>
-      </div>
-      <div class="stat-card">
-        <span class="value">{{ pedidosEnProceso }}</span>
-        <span class="label">Pedidos en proceso</span>
-      </div>
-      <div class="stat-card">
-        <span class="value">{{ usuariosRegistrados }}</span>
-        <span class="label">Usuarios registrados</span>
-      </div>
+      <app-stat-card [title]="'Cuentos publicados'" [value]="cuentosPublicados" [data]="cuentosTrend"></app-stat-card>
+      <app-stat-card [title]="'Pedidos en proceso'" [value]="pedidosEnProceso" [data]="pedidosTrend"></app-stat-card>
+      <app-stat-card [title]="'Usuarios registrados'" [value]="usuariosRegistrados" [data]="usuariosTrend"></app-stat-card>
     </ng-container>
   </section>
 

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.scss
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.scss
@@ -20,8 +20,17 @@
 
   .stats-grid {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 1rem;
+    grid-gap: 1rem;
+    grid-template-columns: 1fr;
+    @media (min-width: 768px) {
+      grid-template-columns: repeat(2, 1fr);
+    }
+    @media (min-width: 1024px) {
+      grid-template-columns: repeat(3, 1fr);
+    }
+    @media (min-width: 1280px) {
+      grid-template-columns: repeat(4, 1fr);
+    }
   }
 
   .stat-card {

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.ts
@@ -4,11 +4,12 @@ import { CuentoService } from '../../../../services/cuento.service';
 import { PedidoService } from '../../../../services/pedido.service';
 import { UserService } from '../../../../services/user.service';
 import { User } from '../../../../model/user.model';
+import { StatCardComponent } from '../../../stat-card/stat-card.component';
 
 @Component({
   selector: 'app-admin-dashboard',
-  // standalone: true,
-  // imports: [],
+  standalone: true,
+  imports: [StatCardComponent],
   templateUrl: './admin-dashboard.component.html',
   styleUrls: ['./admin-dashboard.component.scss']
 })
@@ -17,6 +18,9 @@ export class AdminDashboardComponent implements OnInit {
   pedidosEnProceso = 0;
   usuariosRegistrados = 0;
   ventasTotales = 0;
+  cuentosTrend: number[] = [];
+  pedidosTrend: number[] = [];
+  usuariosTrend: number[] = [];
   isLoading = true;
   errorMensaje: string | null = null;
   usuarios: User[] = [];
@@ -44,6 +48,9 @@ export class AdminDashboardComponent implements OnInit {
         this.pedidosEnProceso = pedidos.length;
         this.usuariosRegistrados = usuarios.length;
         this.usuarios = usuarios;
+        this.cuentosTrend = cuentos.map(c => c.id ?? 0).slice(0, 10);
+        this.pedidosTrend = pedidos.map(p => p.total).slice(0, 10);
+        this.usuariosTrend = usuarios.map((u, i) => i + 1).slice(0, 10);
         this.isLoading = false;
       },
       error: () => {

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.html
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.html
@@ -1,19 +1,11 @@
-<nav class="navbar admin-navbar" role="navigation" aria-label="Menú de administración">
+<nav class="admin-navbar" aria-label="Menú de administración">
+  <button class="hamburger" aria-label="Menú" (click)="toggleMenu()" [hidden]="isDesktop">☰</button>
   <a class="navbar-brand">
     <img appLazyLoad="assets/killa.bmp" alt="Cuentos de Killa" class="logo-img" />
     <span class="brand-text">Cuentos de Killa</span>
   </a>
-  <button class="hamburger" aria-label="Menú" (click)="toggleMenu()">☰</button>
-  <ul class="nav-links" [class.open]="menuAbierto">
-    <li class="close-wrapper" *ngIf="menuAbierto">
-      <button class="close-menu" aria-label="Cerrar" (click)="toggleMenu(false)">✖</button>
-    </li>
-    <li><a routerLink="/admin/dashboard" routerLinkActive="active" (click)="toggleMenu(false)">Dashboard</a></li>
-    <li><a routerLink="/admin/cuentos" routerLinkActive="active" (click)="toggleMenu(false)">Cuentos</a></li>
-    <li><a routerLink="/admin/pedidos" routerLinkActive="active" (click)="toggleMenu(false)">Pedidos</a></li>
-    <li><a routerLink="/admin/usuarios" routerLinkActive="active" (click)="toggleMenu(false)">Usuarios</a></li>
-  </ul>
 </nav>
+<app-admin-drawer [isOpen]="menuAbierto || isDesktop" (closed)="toggleMenu(false)"></app-admin-drawer>
 <main class="admin-content" role="main">
   <router-outlet></router-outlet>
 </main>

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
@@ -1,106 +1,34 @@
 @import '../../../../../styles/variables';
+@import '../../../../../styles/mixins';
 
 .admin-navbar {
-  background-color: $primary;
-  padding: 10px 20px;
+  background-color: $brand-primary;
+  color: #fff;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  color: #fff;
+  gap: $spacing-unit;
+  padding: $spacing-unit/2 $spacing-unit;
   position: sticky;
   top: 0;
-  z-index: 1100;
-  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-}
-
-.admin-navbar .navbar-brand {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  text-decoration: none;
-  background-color: transparent;
-}
-
-.admin-navbar .logo-img {
-  height: 40px;
-  width: auto;
-  object-fit: contain;
-}
-
-.admin-navbar .brand-text {
-  font-size: 1.2rem;
-  font-weight: bold;
-  color: #fff;
-}
-
-.admin-navbar .nav-links {
-  list-style: none;
-  display: flex;
-  align-items: center;
-  gap: 20px;
-  margin: 0;
-  padding: 0;
-}
-
-.admin-navbar .nav-links li {
-  display: flex;
-  align-items: center;
-}
-
-.admin-navbar .nav-links a {
-  color: #fff;
-  text-decoration: none;
-  font-weight: bold;
-  transition: color 0.3s ease;
-}
-
-.admin-navbar .nav-links a:hover {
-  color: #ffeead;
-}
-
-.close-menu,
-.hamburger {
-  background: none;
-  border: none;
-  color: #fff;
-  font-size: 1.5rem;
-  cursor: pointer;
-}
-
-.close-menu {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  display: none;
-}
-
-@media (max-width: 768px) {
-  .admin-navbar .nav-links {
-    position: fixed;
-    top: 0;
-    right: 0;
-    height: 100%;
-    width: 200px;
-    background: $primary;
-    flex-direction: column;
-    padding-top: 4rem;
-    transform: translateX(100%);
-    transition: transform 0.3s ease;
-  }
-
-  .admin-navbar .nav-links.open {
-    transform: translateX(0);
-  }
-
-  .close-menu {
-    display: block;
-  }
+  z-index: 1200;
 
   .hamburger {
-    display: block;
+    @include btn-base;
+    background: transparent;
+    color: #fff;
+  }
+
+  .brand-text {
+    font-weight: bold;
   }
 }
 
 .admin-content {
-  padding: 1rem;
+  padding: $spacing-unit;
+  margin-left: 0;
+
+  @media (min-width: 1024px) {
+    margin-left: 260px;
+  }
 }
+

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.ts
@@ -1,17 +1,28 @@
-import { Component } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { LazyLoadImageDirective } from '../../../../directives/lazy-load-image.directive';
+import { AdminDrawerComponent } from '../../../admin-drawer/admin-drawer.component';
 
 @Component({
   selector: 'app-admin-layout',
   standalone: true,
-  imports: [RouterModule, CommonModule, LazyLoadImageDirective],
+  imports: [RouterModule, CommonModule, LazyLoadImageDirective, AdminDrawerComponent],
   templateUrl: './admin-layout.component.html',
   styleUrls: ['./admin-layout.component.scss']
 })
 export class AdminLayoutComponent {
   menuAbierto = false;
+  isDesktop = false;
+
+  constructor() {
+    this.onResize();
+  }
+
+  @HostListener('window:resize')
+  onResize() {
+    this.isDesktop = window.innerWidth >= 1024;
+  }
 
   toggleMenu(force?: boolean) {
     this.menuAbierto = force !== undefined ? force : !this.menuAbierto;

--- a/src/app/components/pages/admin/admin.module.ts
+++ b/src/app/components/pages/admin/admin.module.ts
@@ -6,7 +6,6 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 // import { HttpClientModule } from '@angular/common/http';
 
 import { AdminLayoutComponent } from './admin-layout/admin-layout.component';
-import { AdminDashboardComponent } from './admin-dashboard/admin-dashboard.component';
 import { AdminCuentosComponent } from './admin-cuentos/admin-cuentos.component';
 import { AdminPedidosComponent } from './admin-pedidos/admin-pedidos.component';
 import { AdminUsuariosComponent } from './admin-usuarios/admin-usuarios.component';
@@ -23,7 +22,7 @@ const routes: Routes = [
     component: AdminLayoutComponent,
     children: [
       { path: '', redirectTo: 'dashboard', pathMatch: 'full' },
-      { path: 'dashboard', component: AdminDashboardComponent },
+      { path: 'dashboard', loadComponent: () => import('./admin-dashboard/admin-dashboard.component').then(m => m.AdminDashboardComponent) },
       { path: 'cuentos', component: AdminCuentosComponent },
       { path: 'cuentos/nuevo', component: CuentoFormComponent },
       { path: 'cuentos/editar/:id', component: CuentoFormComponent },
@@ -35,7 +34,6 @@ const routes: Routes = [
 
 @NgModule({
   declarations: [
-    AdminDashboardComponent,
     AdminCuentosComponent,
     AdminPedidosComponent,
     AdminUsuariosComponent,

--- a/src/app/components/stat-card/stat-card.component.html
+++ b/src/app/components/stat-card/stat-card.component.html
@@ -1,0 +1,12 @@
+<div class="stat-card">
+  <div class="stat-info">
+    <svg *ngIf="icon" class="icon" [innerHTML]="icon"></svg>
+    <div>
+      <span class="value">{{ value }}</span>
+      <span class="title">{{ title }}</span>
+    </div>
+  </div>
+  <svg class="sparkline" viewBox="0 0 100 30" *ngIf="data?.length">
+    <polyline [attr.points]="points" fill="none" stroke="currentColor" stroke-width="2"/>
+  </svg>
+</div>

--- a/src/app/components/stat-card/stat-card.component.scss
+++ b/src/app/components/stat-card/stat-card.component.scss
@@ -1,0 +1,35 @@
+@import '../../styles/variables';
+@import '../../styles/mixins';
+
+.stat-card {
+  @include card-style;
+  display: flex;
+  flex-direction: column;
+  gap: $spacing-unit / 2;
+
+  .stat-info {
+    display: flex;
+    align-items: center;
+    gap: $spacing-unit / 2;
+    .icon {
+      width: 24px;
+      height: 24px;
+    }
+    .value {
+      font-size: 1.25rem;
+      font-weight: bold;
+      color: $brand-primary;
+    }
+    .title {
+      display: block;
+      font-size: 0.875rem;
+      color: $text-dark;
+    }
+  }
+
+  .sparkline {
+    width: 100%;
+    height: 30px;
+    color: $brand-secondary;
+  }
+}

--- a/src/app/components/stat-card/stat-card.component.ts
+++ b/src/app/components/stat-card/stat-card.component.ts
@@ -1,0 +1,26 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-stat-card',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './stat-card.component.html',
+  styleUrls: ['./stat-card.component.scss']
+})
+export class StatCardComponent {
+  @Input() title = '';
+  @Input() value: number | string = 0;
+  @Input() data: number[] = [];
+  @Input() icon = '';
+
+  get points(): string {
+    if (!this.data || this.data.length === 0) return '';
+    const max = Math.max(...this.data);
+    const min = Math.min(...this.data);
+    const range = max - min || 1;
+    return this.data
+      .map((d, i) => `${(i / (this.data.length - 1)) * 100},${100 - ((d - min) / range) * 100}`)
+      .join(' ');
+  }
+}

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -1,6 +1,18 @@
+@import 'variables';
+
 @mixin card-style {
   border-radius: $border-radius;
   box-shadow: $shadow-sm;
   background-color: #fff;
   padding: 1rem;
+}
+
+@mixin btn-base {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: $radius;
+  padding: calc($spacing-unit / 1.5) $spacing-unit;
+  font-weight: 600;
+  cursor: pointer;
 }

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,5 +1,11 @@
-$primary: #a66e38;
-$secondary: #ffad60;
+$brand-primary: #A66E38;
+$brand-secondary: #FFAD60;
+$text-dark: #3F2A14;
+$radius: 8px;
+$spacing-unit: 1rem;
+
+$primary: $brand-primary;
+$secondary: $brand-secondary;
 $accent: #6db37f;
-$border-radius: 12px;
+$border-radius: $radius;
 $shadow-sm: 0 2px 4px rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary
- add SCSS variables and mixins for consistent styles
- create reusable `StatCardComponent`
- create `AdminDrawerComponent` and integrate it into admin layout
- refactor admin dashboard to use stat cards
- hide mini cart when the logged user isn't a regular user

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866a130b6b48327b01b963e3e23ce22