### PR TITLE
Fix missing cuentos route

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -43,6 +43,10 @@ export const routes: Routes = [
         canActivate: [AdminGuard]
       },
       {
+        path: 'cuentos',
+        loadChildren: () => import('./components/pages/cuentos/cuentos.module').then(m => m.CuentosModule)
+      },
+      {
         path: '',
         redirectTo: '/home',
         pathMatch: 'full',


### PR DESCRIPTION
## Summary
- add `/cuentos` page to routing configuration

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ad75f39483279679aaf9aa8ff0b8