### PR TITLE
Fix AdminGuard server redirect

### DIFF
--- a/src/app/guards/admin.guard.ts
+++ b/src/app/guards/admin.guard.ts
@@ -14,7 +14,9 @@ export class AdminGuard implements CanActivate {
     if (user && user.role === 'ADMIN') {
       return true;
     }
-    this.router.navigate(['/']);
+    if (typeof window !== 'undefined') {
+      this.router.navigate(['/']);
+    }
     return false;
   }
 }


### PR DESCRIPTION
## Summary
- prevent server-side redirects in `AdminGuard`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866b6121424832784a86a7c91f4296a