### PR TITLE
Improve sparkline data handling

### DIFF
--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.spec.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.spec.ts
@@ -49,6 +49,9 @@ describe('AdminDashboardComponent', () => {
     expect(component.pedidosEnProceso).toBe(1);
     expect(component.usuariosRegistrados).toBe(3);
     expect(component.usuarios.length).toBe(3);
+    expect(component.cuentosTrend.length).toBeGreaterThanOrEqual(5);
+    expect(component.pedidosTrend.length).toBeGreaterThanOrEqual(5);
+    expect(component.usuariosTrend.length).toBeGreaterThanOrEqual(5);
     expect(component.isLoading).toBeFalse();
     expect(component.errorMensaje).toBeNull();
   });

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.ts
@@ -26,6 +26,12 @@ export class AdminDashboardComponent implements OnInit {
   errorMensaje: string | null = null;
   usuarios: User[] = [];
 
+  private ensureMinLength(data: number[], min = 5): number[] {
+    if (!data || data.length >= min) return data;
+    const last = data.length ? data[data.length - 1] : 0;
+    return data.concat(Array(min - data.length).fill(last));
+  }
+
   constructor(
     private cuentoService: CuentoService,
     private pedidoService: PedidoService,
@@ -49,9 +55,15 @@ export class AdminDashboardComponent implements OnInit {
         this.pedidosEnProceso = pedidos.length;
         this.usuariosRegistrados = usuarios.length;
         this.usuarios = usuarios;
-        this.cuentosTrend = cuentos.map(c => c.id ?? 0).slice(0, 10);
-        this.pedidosTrend = pedidos.map(p => p.total).slice(0, 10);
-        this.usuariosTrend = usuarios.map((u, i) => i + 1).slice(0, 10);
+        this.cuentosTrend = this.ensureMinLength(
+          cuentos.map(c => c.id ?? 0).slice(0, 10)
+        );
+        this.pedidosTrend = this.ensureMinLength(
+          pedidos.map(p => p.total).slice(0, 10)
+        );
+        this.usuariosTrend = this.ensureMinLength(
+          usuarios.map((u, i) => i + 1).slice(0, 10)
+        );
         this.isLoading = false;
       },
       error: () => {

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
@@ -19,6 +19,12 @@
     color: #fff;
   }
 
+  .logo-img {
+    height: 40px;
+    width: auto;
+    object-fit: contain;
+  }
+
   .brand-text {
     font-weight: bold;
   }


### PR DESCRIPTION
## Summary
- pad dashboard data trends to avoid 1-line sparklines
- verify minimum trend length in dashboard unit tests
- style admin layout logo image

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d3fa2ab48327b577fa9b6b37b916