### PR TITLE
Improve cuentos filters and cards

### DIFF
--- a/src/app/components/cuento-card/cuento-card.component.html
+++ b/src/app/components/cuento-card/cuento-card.component.html
@@ -1,17 +1,23 @@
 <div class="cuento-card">
-  <span class="badge" *ngIf="badgeLabel">{{ badgeLabel }}</span>
+  <span class="badge" *ngIf="badgeLabel" [ngClass]="{'nuevo': badgeLabel==='Nuevo', 'top': badgeLabel.toLowerCase().includes('top')}">{{ badgeLabel }}</span>
   <div class="image-wrapper">
     <img #cardImg class="hover-scale" [appLazyLoad]="cuento.imagenUrl || 'assets/placeholder-cuento.jpg'" alt="{{cuento.titulo}}" (load)="imagenCargada()" (error)="cargarImagenPlaceholder($event)">
     <div class="image-placeholder" *ngIf="cargandoImagen"></div>
+    <span class="cat-badge" *ngIf="cuento.categoria">{{ cuento.categoria }}</span>
   </div>
-  <h3>Titulo: {{ cuento.titulo }}</h3>
-  <p>Autor: {{ cuento.autor }}</p>
-  <p>Precio: S/ {{ cuento.precio | number:'1.2-2' }}</p>
-  <p>Agregado el {{ cuento.fechaIngreso | date:'MM-yyyy' }}</p>
+  <div class="cuento-content">
+    <h3 class="cuento-title">{{ cuento.titulo }}</h3>
+    <div class="rating" *ngIf="cuento.rating">
+      <span>{{ getRatingStars(cuento.rating) }}</span>
+    </div>
+    <p class="autor">Autor: {{ cuento.autor }}</p>
+    <p class="excerpt">{{ cuento.descripcionCorta | slice:0:50 }}...</p>
+    <div class="precio"><span class="cuento-price">S/ {{ cuento.precio | number:'1.2-2' }}</span></div>
+  </div>
 
   <div class="acciones">
-    <button class="hover-scale" (click)="verDetalle()">Ver detalle</button>
-    <button *ngIf="!isAdmin && cuento.habilitado" class="hover-scale" (click)="agregarAlCarrito()" [appFlyToCart]="cardImg">Agregar al carrito</button>
+    <button class="ghost-btn" (click)="verDetalle()">Ver detalle</button>
+    <button *ngIf="!isAdmin && cuento.habilitado" class="solid-btn" (click)="agregarAlCarrito()" [appFlyToCart]="cardImg">Añadir carrito</button>
     <ng-container *ngIf="isAdmin">
       <button (click)="editarCuento()" class="admin-button editar hover-scale">Editar</button>
       <button (click)="deshabilitarCuento()" class="admin-button deshabilitar hover-scale">{{ cuento.habilitado ? 'Deshabilitar' : 'Habilitar' }}</button>

--- a/src/app/components/cuento-card/cuento-card.component.scss
+++ b/src/app/components/cuento-card/cuento-card.component.scss
@@ -2,15 +2,13 @@
 @import '../../../styles/mixins';
 
 .cuento-card {
-  @include card-style;
+  position: relative;
   text-align: center;
-  max-width: 300px;
-  margin: auto;
-  
+
   img {
     width: 100%;
-    height: auto;
-    border-radius: 10px;
+    aspect-ratio: 4/3;
+    object-fit: cover;
   }
 
   .image-wrapper {
@@ -23,6 +21,22 @@
     background: linear-gradient(90deg, #e0e0e0 25%, #f0f0f0 50%, #e0e0e0 75%);
     background-size: 200% 100%;
     animation: skeleton-loading 1.2s ease infinite;
+  }
+
+  .cat-badge {
+    position: absolute;
+    bottom: 0.25rem;
+    left: 0.25rem;
+    background: #ffad60;
+    color: #a66e38;
+    padding: 0.1rem 0.4rem;
+    border-top-right-radius: 4px;
+    font-size: 0.75rem;
+  }
+
+  .cuento-content {
+    background: #fff;
+    padding: 1rem;
   }
   .acciones {
     margin-top: 0.5rem;
@@ -51,33 +65,62 @@
     }
   }
 
-  h3 {
-    color: #A66E38;
+  .cuento-title {
+    color: #a66e38;
     margin: 0.5rem 0;
   }
 
-  p {
+  .autor {
     margin: 0.25rem 0;
-    color: #4B3A2F;
+    color: #4b3a2f;
     font-size: 1rem;
   }
 
-  button {
+  .excerpt {
+    color: #4b3a2f;
+    font-size: 0.9rem;
+    margin: 0.25rem 0 0.5rem;
+  }
+
+  .rating span {
+    color: #ffad60;
+    font-size: 0.9rem;
+  }
+
+  .cuento-price {
+    background: #ffad60;
+    color: #fff;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.9rem;
+  }
+
+  .ghost-btn {
+    border: 1px solid #96ceb4;
+    color: #96ceb4;
+    border-radius: 4px;
     padding: 0.5rem 1rem;
-    border: none;
-    border-radius: 6px;
-    background-color: #a6d4b8;
-    color: #333;
-    font-weight: 500;
-    transition: background-color 0.2s ease, transform 0.2s ease;
-  
+    background: transparent;
+    transition: background 0.2s ease, color 0.2s ease;
+    cursor: pointer;
+
     &:hover {
-      background-color: #8cbfa3;
-      transform: scale(1.05);
+      background: #96ceb4;
+      color: #fff;
     }
-  
-    &:active {
-      transform: scale(0.98);
+  }
+
+  .solid-btn {
+    background: #96ceb4;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    transition: background 0.2s ease;
+
+    &:hover {
+      background: #a66e38;
     }
   }
 
@@ -103,13 +146,19 @@
 
   .badge {
     position: absolute;
-    top: 8px;
-    left: 8px;
-    background: #a66e38;
-    color: #fff;
-    padding: 2px 8px;
-    border-radius: $border-radius;
+    top: 0.5rem;
+    right: 0.5rem;
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
     font-size: 0.75rem;
+    color: #fff;
+    &.nuevo {
+      background: #96ceb4;
+    }
+    &.top {
+      background: #a66e38;
+    }
+    animation: none;
   }
 }
 
@@ -130,22 +179,31 @@
 
 :host {
   display: block;
-  border-radius: 12px;
-  background-color: #fff9db;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  border-radius: 6px;
+  background-color: #ffeead;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-  padding: 1rem;
+  overflow: hidden;
   text-align: center;
 
   &:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
+    transform: scale(1.02);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
     cursor: pointer;
   }
 }
 
 :host(:hover) .share-buttons {
   display: flex;
+}
+
+:host(:hover) .badge {
+  animation: blink 1s infinite;
+}
+
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
 }
 
 @keyframes skeleton-loading {

--- a/src/app/components/cuento-card/cuento-card.component.ts
+++ b/src/app/components/cuento-card/cuento-card.component.ts
@@ -66,4 +66,8 @@ export class CuentoCardComponent implements OnInit {
       window.open('https://www.instagram.com/', '_blank');
     }
   }
+
+  getRatingStars(rating: number): string {
+    return '★★★★★'.slice(0, rating) + '☆☆☆☆☆'.slice(rating);
+  }
 }

--- a/src/app/components/pages/cuentos/cuentos.component.html
+++ b/src/app/components/pages/cuentos/cuentos.component.html
@@ -58,7 +58,7 @@
     <button class="btn-filter" type="button">Filtrar</button>
     <button class="btn-clear" type="button" (click)="limpiarFiltros()">Limpiar</button>
   </div>
-  <a class="cta-link" href="#">¿No sabes dónde empezar? ➞ Ver los 5 cuentos más leídos</a>
+  <a class="cta-link" href="#">¿No sabes dónde empezar? → Ver los 5 más leídos</a>
   <div class="grid-cuentos">
     <app-cuento-card
       *ngFor="let cuento of filteredCuentos"
@@ -66,7 +66,9 @@
       (agregar)="agregarAlCarrito($event)"
     ></app-cuento-card>
   </div>
-  <p class="no-results" *ngIf="filteredCuentos.length === 0">
-    ¡Uy! No encontramos ese cuento. Prueba con otra palabra clave o explora nuestras categorías destacadas.
-  </p>
+  <div class="no-results" *ngIf="filteredCuentos.length === 0">
+    <span class="icon">⚠</span>
+    <span>¡Uy! No encontramos ese cuento. Prueba con otra palabra clave.</span>
+  </div>
 </div>
+

--- a/src/app/components/pages/cuentos/cuentos.component.scss
+++ b/src/app/components/pages/cuentos/cuentos.component.scss
@@ -4,7 +4,7 @@
   margin: 0 auto;
 }
 
-.filter-bar {
+  .filter-bar {
   background: #ffeead;
   padding: 1rem;
   border-radius: 8px;
@@ -30,34 +30,56 @@
     pointer-events: none;
   }
 
-  input,
-  select {
-    padding: 0.75rem 0.75rem 0.75rem 2rem;
-    border: 1px solid #ddd;
-    border-radius: 6px;
-    font-size: 1rem;
-    transition: box-shadow 0.3s ease, transform 0.3s ease;
-  }
+    input,
+    select {
+      padding: 0.75rem 0.75rem 0.75rem 2rem;
+      border: 1px solid #ddd;
+      border-radius: 6px;
+      font-size: 1rem;
+      transition: box-shadow 0.3s ease, width 0.3s ease;
+    }
 
-  input:focus {
-    transform: scaleX(1.05);
-    box-shadow: 0 0 0 2px rgba(150, 206, 180, 0.4);
-  }
+    input {
+      width: 200px;
+    }
+
+    input:focus {
+      width: 300px;
+      box-shadow: 0 0 0 3px rgba(150, 206, 180, 0.4);
+    }
 
   select option:checked {
     background: #ffad60;
   }
 
-  .btn-filter,
-  .btn-clear {
-    background: transparent;
-    border: 1px solid #96ceb4;
-    color: #96ceb4;
-    border-radius: 6px;
-    padding: 0.75rem 1.25rem;
-    cursor: pointer;
-    transition: background 0.2s ease;
-  }
+    .btn-filter,
+    .btn-clear {
+      background: transparent;
+      border-radius: 6px;
+      padding: 0.75rem 1.25rem;
+      cursor: pointer;
+      transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+    }
+
+    .btn-filter {
+      border: 1px solid #96ceb4;
+      color: #96ceb4;
+    }
+
+    .btn-filter:hover {
+      background: #96ceb4;
+      color: #fff;
+    }
+
+    .btn-clear {
+      border: 1px solid rgba(166, 110, 56, 0.4);
+      color: rgba(166, 110, 56, 0.6);
+    }
+
+    .btn-clear:hover {
+      border-color: #a66e38;
+      color: #a66e38;
+    }
 
   .btn-filter:hover {
     background: #96ceb4;
@@ -82,12 +104,21 @@
 
 .no-results {
   margin-top: 1rem;
-  text-align: center;
-  font-style: italic;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: #ffad60;
+  color: #a66e38;
+  border-radius: 6px;
+  padding: 0.75rem;
 }
 
 @media (max-width: 600px) {
   .grid-cuentos {
     grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  }
+  .filter-bar input {
+    width: 100%;
   }
 }


### PR DESCRIPTION
## Summary
- add CTA link and friendly no-results box
- refine search filter styles with animated input
- redesign cuento cards with category badges, rating stars and new buttons

## Testing
- `npm test --silent` *(fails: ng not found)*
- `npx tsc -p tsconfig.app.json --noEmit` *(fails: cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6866e7060d08832780c7352df37f9bf8