### PR TITLE
Remove unused admin navbar

### DIFF
--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.html
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.html
@@ -1,3 +1,4 @@
+<!--
 <nav class="admin-navbar" aria-label="Menú de administración">
   <button class="hamburger" aria-label="Menú" (click)="toggleMenu()" [hidden]="isDesktop">☰</button>
   <a class="navbar-brand">
@@ -5,6 +6,7 @@
     <span class="brand-text">Cuentos de Killa</span>
   </a>
 </nav>
+-->
 <app-admin-drawer [isOpen]="menuAbierto || isDesktop" (closed)="toggleMenu(false)"></app-admin-drawer>
 <main class="admin-content" role="main">
   <router-outlet></router-outlet>

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
@@ -2,6 +2,7 @@
 @import '../../../../../styles/variables';
 @import '../../../../../styles/mixins';
 
+/*
 .admin-navbar {
   background-color: $brand-primary;
   color: #fff;
@@ -29,6 +30,7 @@
     font-weight: bold;
   }
 }
+*/
 
 .admin-content {
   padding: $spacing-unit;


### PR DESCRIPTION
## Summary
- comment out the admin navbar markup
- wrap the admin navbar styles in a block comment

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866ea8bfc188327b9811e9a301cdf29