### PR TITLE
Add dynamic button theming

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,4 @@
-import { ApplicationConfig, provideZoneChangeDetection, importProvidersFrom } from '@angular/core';
+import { ApplicationConfig, provideZoneChangeDetection, importProvidersFrom, APP_INITIALIZER } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
@@ -7,11 +7,23 @@ import { provideHttpClient,withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async'; // 👈 este es el nuevo import
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { authInterceptor } from './services/auth.interceptor';
+import { ThemeService } from './services/theme.service';
 
 
 
 export const appConfig: ApplicationConfig = {
-  providers: [provideZoneChangeDetection({ eventCoalescing: true }), provideRouter(routes), provideClientHydration(), 
-     provideHttpClient(withInterceptors([authInterceptor])), provideAnimationsAsync(),
-     importProvidersFrom(MatSnackBarModule)]
+  providers: [
+    provideZoneChangeDetection({ eventCoalescing: true }),
+    provideRouter(routes),
+    provideClientHydration(),
+    provideHttpClient(withInterceptors([authInterceptor])),
+    provideAnimationsAsync(),
+    importProvidersFrom(MatSnackBarModule),
+    {
+      provide: APP_INITIALIZER,
+      useFactory: (ts: ThemeService) => () => ts.loadTheme(),
+      deps: [ThemeService],
+      multi: true,
+    },
+  ]
 };

--- a/src/app/components/cuento-card/cuento-card.component.html
+++ b/src/app/components/cuento-card/cuento-card.component.html
@@ -16,8 +16,8 @@
   </div>
 
   <div class="acciones">
-    <button class="ghost-btn" (click)="verDetalle()">Ver detalle</button>
-    <button *ngIf="!isAdmin && cuento.habilitado" class="solid-btn" (click)="agregarAlCarrito()" [appFlyToCart]="cardImg">Añadir carrito</button>
+    <button class="btn btn-ghost" (click)="verDetalle()">Ver detalle</button>
+    <button *ngIf="!isAdmin && cuento.habilitado" class="btn btn-primary" (click)="agregarAlCarrito()" [appFlyToCart]="cardImg">Añadir carrito</button>
     <ng-container *ngIf="isAdmin">
       <button (click)="editarCuento()" class="admin-button editar hover-scale">Editar</button>
       <button (click)="deshabilitarCuento()" class="admin-button deshabilitar hover-scale">{{ cuento.habilitado ? 'Deshabilitar' : 'Habilitar' }}</button>

--- a/src/app/components/cuento-card/cuento-card.component.scss
+++ b/src/app/components/cuento-card/cuento-card.component.scss
@@ -95,34 +95,6 @@
     font-size: 0.9rem;
   }
 
-  .ghost-btn {
-    border: 1px solid #96ceb4;
-    color: #96ceb4;
-    border-radius: 4px;
-    padding: 0.5rem 1rem;
-    background: transparent;
-    transition: background 0.2s ease, color 0.2s ease;
-    cursor: pointer;
-
-    &:hover {
-      background: #96ceb4;
-      color: #fff;
-    }
-  }
-
-  .solid-btn {
-    background: #96ceb4;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-    padding: 0.5rem 1rem;
-    cursor: pointer;
-    transition: background 0.2s ease;
-
-    &:hover {
-      background: #a66e38;
-    }
-  }
 
   .share-buttons {
     display: none;

--- a/src/app/components/hero-banner/hero-banner.component.html
+++ b/src/app/components/hero-banner/hero-banner.component.html
@@ -5,7 +5,7 @@
     <p class="subtitle">{{ subtitle }}</p>
     <form (submit)="suscribirse(email.value)" class="newsletter-form" aria-label="Suscripción" id="newsletter-form">
       <input #email type="email" placeholder="Tu correo electrónico" aria-label="Tu correo electrónico">
-      <button type="submit">Suscribirme</button>
+      <button type="submit" class="btn btn-secondary">Suscribirme</button>
     </form>
   </div>
 </section>

--- a/src/app/components/hero-banner/hero-banner.component.scss
+++ b/src/app/components/hero-banner/hero-banner.component.scss
@@ -40,18 +40,7 @@
   }
 
   button {
-    padding: 0.5rem 1.5rem;
-    background-color: $secondary;
-    border: none;
     border-radius: 0 9999px 9999px 0;
-    font-weight: 600;
-    cursor: pointer;
-    color: #fff;
-    transition: background-color 0.2s;
-
-    &:hover {
-      background-color: darken($primary, 10%);
-    }
   }
 }
 

--- a/src/app/components/navbar/navbar.component.scss
+++ b/src/app/components/navbar/navbar.component.scss
@@ -338,8 +338,8 @@
   }
 }
 .btn-primary {
-  background-color: #a66e38;
-  color: #fff;
+  background-color: var(--btn-primary-bg);
+  color: var(--btn-primary-text);
   padding: 10px 16px;
   border: none;
   border-radius: 6px;
@@ -352,7 +352,10 @@
   transition: background-color 0.3s;
 
   &:hover {
-    background-color: #85562d;
+    filter: brightness(1.1);
+  }
+  &:active {
+    transform: scale(0.98);
   }
 }
 

--- a/src/app/components/pages/checkout/checkout.component.scss
+++ b/src/app/components/pages/checkout/checkout.component.scss
@@ -59,8 +59,8 @@
   }
 
   .btn-primary {
-    background-color: #A66E38;
-    color: white;
+    background-color: var(--btn-primary-bg);
+    color: var(--btn-primary-text);
     padding: 14px;
     font-weight: bold;
     border: none;
@@ -72,7 +72,10 @@
     box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 
     &:hover {
-      background-color: #8a582e;
+      filter: brightness(1.1);
+    }
+    &:active {
+      transform: scale(0.98);
     }
   }
 }

--- a/src/app/components/pages/cuentos/cuentos.component.html
+++ b/src/app/components/pages/cuentos/cuentos.component.html
@@ -55,8 +55,8 @@
         <option value="4">4⭐ o más</option>
       </select>
     </div>
-    <button class="btn-filter" type="button">Filtrar</button>
-    <button class="btn-clear" type="button" (click)="limpiarFiltros()">Limpiar</button>
+    <button class="btn btn-secondary" type="button">Filtrar</button>
+    <button class="btn btn-ghost" type="button" (click)="limpiarFiltros()">Limpiar</button>
   </div>
   <a class="cta-link" href="#">¿No sabes dónde empezar? → Ver los 5 más leídos</a>
   <div class="grid-cuentos">

--- a/src/app/components/pages/cuentos/cuentos.component.scss
+++ b/src/app/components/pages/cuentos/cuentos.component.scss
@@ -52,39 +52,6 @@
     background: #ffad60;
   }
 
-    .btn-filter,
-    .btn-clear {
-      background: transparent;
-      border-radius: 6px;
-      padding: 0.75rem 1.25rem;
-      cursor: pointer;
-      transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-    }
-
-    .btn-filter {
-      border: 1px solid #96ceb4;
-      color: #96ceb4;
-    }
-
-    .btn-filter:hover {
-      background: #96ceb4;
-      color: #fff;
-    }
-
-    .btn-clear {
-      border: 1px solid rgba(166, 110, 56, 0.4);
-      color: rgba(166, 110, 56, 0.6);
-    }
-
-    .btn-clear:hover {
-      border-color: #a66e38;
-      color: #a66e38;
-    }
-
-  .btn-filter:hover {
-    background: #96ceb4;
-    color: #fff;
-  }
 }
 
 .grid-cuentos {

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  private palettes: Record<string, Record<string, string>> = {
+    "1": {
+      "--btn-primary-bg": "#a66e38",
+      "--btn-primary-text": "#ffffff",
+      "--btn-secondary-bg": "#ffad60",
+      "--btn-secondary-text": "#ffffff",
+      "--btn-ghost-border": "#a66e38",
+      "--btn-ghost-text": "#a66e38",
+      "--btn-tertiary-bg": "#96ceb4",
+      "--btn-tertiary-text": "#ffffff",
+      "--btn-disabled-bg": "#eeeeee",
+      "--btn-disabled-text": "#aaaaaa"
+    },
+    "2": {
+      "--btn-primary-bg": "#96ceb4",
+      "--btn-primary-text": "#ffffff",
+      "--btn-secondary-bg": "#ffad60",
+      "--btn-secondary-text": "#ffffff",
+      "--btn-ghost-border": "#96ceb4",
+      "--btn-ghost-text": "#96ceb4",
+      "--btn-tertiary-bg": "#a66e38",
+      "--btn-tertiary-text": "#ffffff",
+      "--btn-disabled-bg": "#f7f4e9",
+      "--btn-disabled-text": "#cccccc"
+    },
+    "3": {
+      "--btn-primary-bg": "#ffad60",
+      "--btn-primary-text": "#ffffff",
+      "--btn-secondary-bg": "#ffeead",
+      "--btn-secondary-text": "#a66e38",
+      "--btn-ghost-border": "#ffad60",
+      "--btn-ghost-text": "#ffad60",
+      "--btn-tertiary-bg": "#96ceb4",
+      "--btn-tertiary-text": "#ffffff",
+      "--btn-disabled-bg": "#faf5e0",
+      "--btn-disabled-text": "#bbbbbb"
+    }
+  };
+
+  constructor(private http: HttpClient) {}
+
+  loadTheme(): Promise<void> {
+    return firstValueFrom(
+      this.http.get<{ opcion: string }>("/api/config/theme")
+    )
+      .then((cfg) => this.apply(cfg.opcion))
+      .catch(() => this.apply("1"));
+  }
+
+  private apply(option: string) {
+    const vars = this.palettes[option] || this.palettes["1"];
+    Object.entries(vars).forEach(([key, val]) =>
+      document.documentElement.style.setProperty(key, val)
+    );
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,6 +3,19 @@
 @import 'styles/mixins';
 @import 'styles/buttons';
 
+:root {
+  --btn-primary-bg: #a66e38;
+  --btn-primary-text: #ffffff;
+  --btn-secondary-bg: #ffad60;
+  --btn-secondary-text: #ffffff;
+  --btn-ghost-border: #a66e38;
+  --btn-ghost-text: #a66e38;
+  --btn-tertiary-bg: #96ceb4;
+  --btn-tertiary-text: #ffffff;
+  --btn-disabled-bg: #eeeeee;
+  --btn-disabled-text: #aaaaaa;
+}
+
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
 // styles.scss

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -2,19 +2,45 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: none;
-  border-radius: 8px;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
   font-weight: 600;
-  padding: 0.75rem 1rem;
   cursor: pointer;
+  transition: background-color 0.15s ease, filter 0.15s ease, transform 0.1s;
+  border: none;
+
+  &:hover:not(.btn-disabled) {
+    filter: brightness(1.1);
+  }
+
+  &:active:not(.btn-disabled) {
+    transform: scale(0.98);
+  }
 }
 
 .btn-primary {
-  background-color: $primary;
-  color: #fff;
+  background-color: var(--btn-primary-bg);
+  color: var(--btn-primary-text);
 }
 
 .btn-secondary {
-  background-color: $secondary;
-  color: #fff;
+  background-color: var(--btn-secondary-bg);
+  color: var(--btn-secondary-text);
+}
+
+.btn-ghost {
+  background-color: transparent;
+  border: 1px solid var(--btn-ghost-border);
+  color: var(--btn-ghost-text);
+}
+
+.btn-tertiary {
+  background-color: var(--btn-tertiary-bg);
+  color: var(--btn-tertiary-text);
+}
+
+.btn-disabled {
+  background-color: var(--btn-disabled-bg);
+  color: var(--btn-disabled-text);
+  cursor: not-allowed;
 }


### PR DESCRIPTION
## Summary
- implement `ThemeService` to load palette from backend
- apply palette via `APP_INITIALIZER`
- define CSS variables for button colors
- update global button styles to use CSS variables
- refactor button usages in hero banner, cuentos list, and cuento card
- adjust SCSS in navbar and checkout for dynamic colors
- fix theme loading

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866fae4e1cc8327a6c3b1ee41e62861