### PR TITLE
Implement alert banner and global mini cart

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,2 +1,3 @@
 
 <router-outlet></router-outlet>
+<app-mini-cart *ngIf="showMiniCart"></app-mini-cart>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,14 +1,31 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterOutlet, Router } from '@angular/router';
+import { MiniCartComponent } from './components/mini-cart/mini-cart.component';
+import { AuthService } from './services/auth.service';
 
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet,],
+  imports: [RouterOutlet, MiniCartComponent],
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
   title = 'cuentos-killa-FE';
+  userRole: string | null = null;
+
+  constructor(private auth: AuthService, private router: Router) {
+    const user = this.auth.getUser();
+    this.userRole = user?.role ?? null;
+    this.auth.usuarioLogueado$.subscribe(u => this.userRole = u?.role ?? null);
+  }
+
+  get showMiniCart(): boolean {
+    const url = this.router.url;
+    const allowedRoutes = url.startsWith('/home') ||
+      url.startsWith('/cuentos') ||
+      url.startsWith('/cuento/');
+    return this.userRole === 'USER' && allowedRoutes;
+  }
 }

--- a/src/app/components/alert-banner/alert-banner.component.html
+++ b/src/app/components/alert-banner/alert-banner.component.html
@@ -1,0 +1,3 @@
+<div class="alert" [ngClass]="'alert--' + type" role="alert">
+  <ng-content></ng-content>
+</div>

--- a/src/app/components/alert-banner/alert-banner.component.scss
+++ b/src/app/components/alert-banner/alert-banner.component.scss
@@ -1,0 +1,30 @@
+.alert {
+  padding: 1rem;
+  border-radius: 0.5rem;
+  margin-bottom: 1rem;
+  border-left: 4px solid;
+}
+
+.alert--info {
+  background-color: #FFEEAD;
+  border-color: #A66E38;
+  color: #38290F;
+}
+
+.alert--success {
+  background-color: #96CEB4;
+  border-color: #A66E38;
+  color: #38290F;
+}
+
+.alert--warning {
+  background-color: #FFAD60;
+  border-color: #A66E38;
+  color: #38290F;
+}
+
+.alert--error {
+  background-color: #E56B6F;
+  border-color: #A66E38;
+  color: #fff;
+}

--- a/src/app/components/alert-banner/alert-banner.component.ts
+++ b/src/app/components/alert-banner/alert-banner.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-alert-banner',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './alert-banner.component.html',
+  styleUrls: ['./alert-banner.component.scss']
+})
+export class AlertBannerComponent {
+  @Input() type: 'success' | 'warning' | 'error' | 'info' = 'info';
+}

--- a/src/app/components/layout/layout.component.html
+++ b/src/app/components/layout/layout.component.html
@@ -5,5 +5,5 @@
 </main>
 
 <app-drawer-menu></app-drawer-menu>
-<app-mini-cart *ngIf="user?.role === 'USER' && !['/checkout','/pedidos','/perfil'].includes(router.url)"></app-mini-cart>
+
 

--- a/src/app/components/layout/layout.component.ts
+++ b/src/app/components/layout/layout.component.ts
@@ -4,14 +4,13 @@ import { CommonModule } from '@angular/common';
 import { NavbarComponent } from '../navbar/navbar.component';
 import { DrawerMenuComponent } from '../drawer-menu/drawer-menu.component';
 import { DrawerService } from '../../services/drawer.service';
-import { MiniCartComponent } from '../mini-cart/mini-cart.component';
 import { AuthService } from '../../services/auth.service';
 import { User } from '../../model/user.model';
 
 @Component({
   selector: 'app-layout',
   standalone: true,
-  imports: [CommonModule, RouterOutlet, NavbarComponent, DrawerMenuComponent, MiniCartComponent],
+  imports: [CommonModule, RouterOutlet, NavbarComponent, DrawerMenuComponent],
   templateUrl: './layout.component.html',
   styleUrls: ['./layout.component.scss']
 })

--- a/src/app/components/mini-cart/mini-cart.component.scss
+++ b/src/app/components/mini-cart/mini-cart.component.scss
@@ -1,6 +1,6 @@
 .floating-cart {
   position: fixed;
-  bottom: calc(1rem + 72px);
+  bottom: 1rem;
   right: 1rem;
   width: 56px;
   height: 56px;
@@ -13,7 +13,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  z-index: 1200;
+  z-index: 9999;
 
   .badge {
     position: absolute;
@@ -38,7 +38,7 @@
   .floating-cart {
     width: 48px;
     height: 48px;
-    bottom: calc(1rem + 72px);
+    bottom: 1rem;
   }
 }
 

--- a/src/app/components/pages/pago/pago.component.html
+++ b/src/app/components/pages/pago/pago.component.html
@@ -5,13 +5,9 @@
   <p>Estado del pedido: <span class="font-semibold">{{ orderStatus }}</span></p>
   <p class="progress-text">1. Pedido generado → 2. Pago validado → 3. Pedido enviado</p>
 
-  <div *ngIf="mensaje" [ngClass]="{
-        'success-mensaje': mensajeTipo === 'success',
-        'error-mensaje': mensajeTipo === 'error',
-        'info-mensaje': mensajeTipo === 'info'
-      }" class="mensaje">
-    <p>{{ mensaje }}</p>
-  </div>
+  <app-alert-banner *ngIf="mensaje" [type]="mensajeTipo">
+    {{ mensaje }}
+  </app-alert-banner>
 
   <div *ngIf="orderStatus === 'Pago Verificado'" class="payment-success-message">
     <p>Tu pago ha sido verificado exitosamente.</p>

--- a/src/app/components/pages/pago/pago.component.scss
+++ b/src/app/components/pages/pago/pago.component.scss
@@ -168,31 +168,6 @@
   }
 }
 
-.mensaje {
-  text-align: center;
-  padding: 1rem;
-  border-radius: 8px;
-  margin-bottom: 1rem;
-  font-size: 1rem;
-}
-
-.success-mensaje {
-  background-color: #d4edda;
-  color: #155724;
-  border: 1px solid #c3e6cb;
-}
-
-.error-mensaje {
-  background-color: #f8d7da;
-  color: #721c24;
-  border: 1px solid #f5c6cb;
-}
-
-.info-mensaje {
-  background-color: #d1ecf1;
-  color: #0c5460;
-  border: 1px solid #bee5eb;
-}
 
 .btn-confirmar {
   background-color: #ffad60;

--- a/src/app/components/pages/pago/pago.component.ts
+++ b/src/app/components/pages/pago/pago.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { RouterModule, ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
+import { AlertBannerComponent } from '../../alert-banner/alert-banner.component';
 import { PedidoService } from '../../../services/pedido.service';
 import { PagoService } from '../../../services/pago.service'; // Added PagoService import
 import { environment } from '../../../../environments/environment';
@@ -8,7 +9,7 @@ import { environment } from '../../../../environments/environment';
 @Component({
   selector: 'app-pago',
   standalone: true,
-  imports: [RouterModule, CommonModule],
+  imports: [RouterModule, CommonModule, AlertBannerComponent],
   templateUrl: './pago.component.html',
   styleUrls: ['./pago.component.scss']
 })


### PR DESCRIPTION
## Summary
- add `AlertBannerComponent` and styles for success/info/warning/error banners
- use `AlertBannerComponent` in payment page
- move mini-cart to app component for global display
- adjust mini-cart positioning and hide for admin
- show mini cart only for USER role on home/cuentos/detalle routes

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e53039ec8327b700c7965d7893d4