### PR TITLE
Integrate Sentry monitoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,9 @@
         "express": "^4.18.2",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
-        "zone.js": "~0.14.3"
+        "zone.js": "~0.14.3",
+        "@sentry/angular-ivy": "^8.0.0",
+        "@sentry/tracing": "^8.0.0"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^18.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "express": "^4.18.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
-    "zone.js": "~0.14.3"
+    "zone.js": "~0.14.3",
+    "@sentry/angular-ivy": "^8.0.0",
+    "@sentry/tracing": "^8.0.0"
   },
   "devDependencies": {
 "@angular-devkit/build-angular": "^18.0.0",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,13 +1,14 @@
-import { ApplicationConfig, provideZoneChangeDetection, importProvidersFrom, APP_INITIALIZER } from '@angular/core';
+import { ApplicationConfig, provideZoneChangeDetection, importProvidersFrom, APP_INITIALIZER, ErrorHandler } from '@angular/core';
 import { provideRouter } from '@angular/router';
 
 import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideHttpClient,withInterceptors } from '@angular/common/http';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async'; // 👈 este es el nuevo import
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { authInterceptor } from './services/auth.interceptor';
 import { ThemeService } from './services/theme.service';
+import * as Sentry from '@sentry/angular-ivy';
 
 
 
@@ -23,6 +24,17 @@ export const appConfig: ApplicationConfig = {
       provide: APP_INITIALIZER,
       useFactory: (ts: ThemeService) => () => ts.loadTheme(),
       deps: [ThemeService],
+      multi: true,
+    },
+    {
+      provide: ErrorHandler,
+      useValue: Sentry.createErrorHandler(),
+    },
+    Sentry.TraceService,
+    {
+      provide: APP_INITIALIZER,
+      useFactory: () => () => {},
+      deps: [Sentry.TraceService],
       multi: true,
     },
   ]

--- a/src/environments/environment-local.ts
+++ b/src/environments/environment-local.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  apiBaseUrl: 'http://localhost:8080/api'
+  apiBaseUrl: 'http://localhost:8080/api',
+  sentryDsn: 'https://9c7ad635f6cf04f87a9724db8efeaf9f@o4509612268912640.ingest.us.sentry.io/4509612284116992'
 };

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiBaseUrl: 'https://cuentos-killa-be-1.onrender.com/api'
+  apiBaseUrl: 'https://cuentos-killa-be-1.onrender.com/api',
+  sentryDsn: 'https://9c7ad635f6cf04f87a9724db8efeaf9f@o4509612268912640.ingest.us.sentry.io/4509612284116992'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: false,
-  apiBaseUrl: 'http://localhost:8080/api'
+  apiBaseUrl: 'http://localhost:8080/api',
+  sentryDsn: 'https://9c7ad635f6cf04f87a9724db8efeaf9f@o4509612268912640.ingest.us.sentry.io/4509612284116992'
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,20 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
+import * as Sentry from '@sentry/angular-ivy';
+import { BrowserTracing } from '@sentry/tracing';
+import { environment } from './environments/environment';
+
+Sentry.init({
+  dsn: environment.sentryDsn,
+  integrations: [
+    new BrowserTracing({
+      routingInstrumentation: Sentry.routingInstrumentation,
+    }),
+  ],
+  sendDefaultPii: true,
+  tracesSampleRate: 1.0,
+});
 
 bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- add Sentry DSN to environment configs
- initialize Sentry and tracing in `main.ts`
- wire up Sentry error handler and tracing service in `app.config.ts`
- declare new Sentry dependencies
- upgrade Sentry packages for Angular 18 compatibility

## Testing
- `npm run build` *(fails: ng not found)*
- `npm install` *(fails: 403 Forbidden - registry access blocked)*


------
https://chatgpt.com/codex/tasks/task_e_6868411ed8548327a410c66b20787cc0