### PR TITLE
Fix admin layout on mobile

### DIFF
--- a/src/app/components/admin-drawer/admin-drawer.component.scss
+++ b/src/app/components/admin-drawer/admin-drawer.component.scss
@@ -7,8 +7,9 @@ $drawer-width: 260px;
   border-right: 1px solid rgba($text-dark, .1);
   width: $drawer-width;
   height: 100vh;
-  position: sticky;
+  position: fixed;
   top: 0;
+  left: 0;
   transform: translateX(-100%);
   transition: transform .3s ease;
   z-index: 1000;
@@ -34,7 +35,6 @@ $drawer-width: 260px;
   }
   &.open {
     transform: translateX(0);
-    position: absolute;
   }
 }
 
@@ -47,10 +47,10 @@ $drawer-width: 260px;
 
 @media (min-width: 1024px) {
   .admin-drawer {
-    // transform: translateX(0);
-    // position: sticky;
-  top: 64px;
-  height: calc(100vh - 64px);
+    position: sticky;
+    transform: none;
+    top: 70px;
+    height: calc(100vh - 70px);
   }
   .backdrop { display:none; }
 }

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.html
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.html
@@ -1,4 +1,3 @@
-<!--
 <nav class="admin-navbar" aria-label="Menú de administración">
   <button class="hamburger" aria-label="Menú" (click)="toggleMenu()" [hidden]="isDesktop">☰</button>
   <a class="navbar-brand">
@@ -6,7 +5,6 @@
     <span class="brand-text">Cuentos de Killa</span>
   </a>
 </nav>
--->
 <app-admin-drawer [isOpen]="menuAbierto || isDesktop" (closed)="toggleMenu(false)"></app-admin-drawer>
 <main class="admin-content" role="main">
   <router-outlet></router-outlet>

--- a/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
+++ b/src/app/components/pages/admin/admin-layout/admin-layout.component.scss
@@ -2,7 +2,6 @@
 @import '../../../../../styles/variables';
 @import '../../../../../styles/mixins';
 
-/*
 .admin-navbar {
   background-color: $brand-primary;
   color: #fff;
@@ -30,7 +29,6 @@
     font-weight: bold;
   }
 }
-*/
 
 .admin-content {
   padding: $spacing-unit;


### PR DESCRIPTION
## Summary
- display admin drawer toggle button by default
- keep admin drawer fixed

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fd0360348327aa62771846758816