### PR TITLE
Fix package.json syntax error

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "zone.js": "~0.14.3",
     "chart.js": "^4.4.0",
     "ng2-charts": "^4.0.0",
-    "date-fns": "^2.30.0"
+    "date-fns": "^2.30.0",
     "@sentry/angular-ivy": "^7.120.3",
     "@sentry/tracing": "^7.120.3"
   },


### PR DESCRIPTION
## Summary
- add a missing comma in `package.json`

## Testing
- `node -e "require('./package.json'); console.log('valid json')"`
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868b00f42ac832796de9b82fbd98168