### PR TITLE
Fix Angular build 'routes' undefined

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -38,6 +38,9 @@
             "scripts": [],
             "server": "src/main.server.ts",
             "prerender": true,
+            "prerenderOptions": {
+              "routes": []
+            },
             "ssr": {
               "entry": "server.ts"
             }


### PR DESCRIPTION
## Summary
- add empty `prerenderOptions.routes` to avoid undefined error during SSR build

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868c3a22da08327b8548cb68923b56a