### PR TITLE
Fix navbar cart link to open mini cart

### DIFF
--- a/src/app/components/mini-cart/mini-cart.component.ts
+++ b/src/app/components/mini-cart/mini-cart.component.ts
@@ -4,6 +4,7 @@ import { Router } from '@angular/router';
 import { CartService } from '../../services/carrito.service';
 import { Cuento } from '../../model/cuento.model';
 import { DrawerService } from '../../services/drawer.service';
+import { MiniCartService } from '../../services/mini-cart.service';
 
 @Component({
   selector: 'app-mini-cart',
@@ -19,11 +20,13 @@ export class MiniCartComponent implements OnInit {
   constructor(
     private cart: CartService,
     private router: Router,
-    public drawer: DrawerService
+    public drawer: DrawerService,
+    private miniCart: MiniCartService
   ) {}
 
   ngOnInit(): void {
     this.cart.items$.subscribe(items => (this.items = items));
+    this.miniCart.isOpen$.subscribe(open => (this.open = open));
   }
 
   get totalQuantity(): number {
@@ -35,13 +38,11 @@ export class MiniCartComponent implements OnInit {
   }
 
   openCart() {
-    this.open = true;
-    document.body.style.overflow = 'hidden';
+    this.miniCart.open();
   }
 
   closeCart() {
-    this.open = false;
-    document.body.style.overflow = '';
+    this.miniCart.close();
   }
 
   remove(id: number) {

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -43,29 +43,3 @@
   </ul>
   <div id="cart-announce" class="visually-hidden" aria-live="polite"></div>
 </nav>
-
-<!-- Drawer del Carrito -->
-<aside class="cart-drawer" [class.open]="carritoAbierto">
-  <div class="cart-header">
-    <h3>Mi Carrito</h3>
-    <button class="close-btn" (click)="cerrarCarrito()" aria-label="Cerrar carrito">✖</button>
-  </div>
-  <div class="cart-body">
-    <div class="carrito-item" *ngFor="let item of itemsCarrito">
-      <i class="fa fa-book"></i>
-      <button class="delete-btn" (click)="CartService.removeItem(item.cuento.id)" aria-label="Eliminar del carrito">❌</button>
-      <span class="titulo-cuento">{{ item.cuento.titulo }}</span>
-      <span *ngIf="item.cantidad" class="cantidad">(x{{ item.cantidad }})</span>
-      <span class="precio-item">
-        S/ {{ (item.cuento.precio * item.cantidad) | number:'1.2-2' }}
-      </span>
-    </div>
-    <div class="subtotal-container">
-      <span class="subtotal-label">Subtotal:</span>
-      <span class="subtotal-valor">{{ calcularSubtotal() | currency:'PEN' }}</span>
-    </div>
-    <button class="btn-primary" (click)="irACheckout()">Checkout</button>
-  </div>
-</aside>
-<!-- Overlay del carrito -->
-<div class="cart-overlay" [class.open]="carritoAbierto" (click)="cerrarCarrito()"></div>

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -4,6 +4,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { CartService } from '../../services/carrito.service';
 import { Router, RouterModule } from '@angular/router';
 import { DrawerService } from '../../services/drawer.service';
+import { MiniCartService } from '../../services/mini-cart.service';
 
 import { CartModalComponent } from '../cart-modal/cart-modal.component';
 import { AuthService } from '../../services/auth.service';
@@ -30,7 +31,6 @@ import { LazyLoadImageDirective } from '../../directives/lazy-load-image.directi
   ]
 })
 export class NavbarComponent implements OnInit {
-  carritoAbierto = false; // 🔥
   cantidadItems: number = 0;
   user: User | null = null;
   mostrarPerfil = false;
@@ -40,7 +40,8 @@ export class NavbarComponent implements OnInit {
     public CartService: CartService,
     public authService: AuthService,
     private router: Router,
-    public drawer: DrawerService
+    public drawer: DrawerService,
+    private miniCart: MiniCartService
   ) {
 
     this.actualizarCantidad();
@@ -81,10 +82,10 @@ export class NavbarComponent implements OnInit {
     return this.itemsCarrito.reduce((total, item) => total + (item.cuento.precio * item.cantidad), 0);
   }
   abrirCarrito() {
-    this.carritoAbierto = true;
+    this.miniCart.open();
   }
   cerrarCarrito() {
-    this.carritoAbierto = false;
+    this.miniCart.close();
   }
 
   togglePerfil() {

--- a/src/app/services/mini-cart.service.ts
+++ b/src/app/services/mini-cart.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class MiniCartService {
+  private _isOpen = new BehaviorSubject<boolean>(false);
+  readonly isOpen$ = this._isOpen.asObservable();
+
+  open() {
+    this._isOpen.next(true);
+    if (typeof document !== 'undefined') {
+      document.body.style.overflow = 'hidden';
+    }
+  }
+
+  close() {
+    this._isOpen.next(false);
+    if (typeof document !== 'undefined') {
+      document.body.style.overflow = '';
+    }
+  }
+
+  toggle() {
+    this._isOpen.value ? this.close() : this.open();
+  }
+}


### PR DESCRIPTION
## Summary
- add `MiniCartService` to manage mini-cart visibility
- subscribe to `MiniCartService` in `MiniCartComponent`
- open/close mini-cart from navbar via `MiniCartService`
- remove obsolete cart drawer markup

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686911c067288327a121c331c299bc00