### PR TITLE
Fix admin dashboard route

### DIFF
--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.module.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.module.ts
@@ -1,13 +1,18 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
+import { RouterModule, Routes } from '@angular/router';
 import { NgChartsModule } from 'ng2-charts';
 import { AdminDashboardComponent } from './admin-dashboard.component';
 import { StatCardComponent } from '../../../stat-card/stat-card.component';
 
+const routes: Routes = [
+  { path: '', component: AdminDashboardComponent }
+];
+
 @NgModule({
   declarations: [AdminDashboardComponent],
-  imports: [CommonModule, FormsModule, NgChartsModule, StatCardComponent],
+  imports: [CommonModule, FormsModule, NgChartsModule, RouterModule.forChild(routes), StatCardComponent],
   exports: [AdminDashboardComponent]
 })
 export class AdminDashboardModule {}


### PR DESCRIPTION
## Summary
- configure routing for AdminDashboard module so `/admin/dashboard` loads correctly

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869110a68c08327b3731c0f00a170a4