### PR TITLE
Implement badges and pricing metadata

### DIFF
--- a/src/app/components/cuento-card/cuento-card.component.html
+++ b/src/app/components/cuento-card/cuento-card.component.html
@@ -1,18 +1,30 @@
 <div class="cuento-card">
-  <span class="badge" *ngIf="badgeLabel" [ngClass]="{'nuevo': badgeLabel==='Nuevo', 'top': badgeLabel.toLowerCase().includes('top')}">{{ badgeLabel }}</span>
+  <div class="badges">
+    <span class="badge category" *ngIf="cuento.categoria">{{ cuento.categoria }}</span>
+    <span class="badge nuevo" *ngIf="badgeLabel==='Nuevo'">Nuevo</span>
+    <span class="badge top" *ngIf="badgeLabel && badgeLabel!=='Nuevo'">{{ badgeLabel }}</span>
+    <span class="badge oferta" *ngIf="hasDiscount">-{{ cuento.descuento }}% OFF</span>
+  </div>
   <div class="image-wrapper">
     <img #cardImg class="hover-scale" [appLazyLoad]="cuento.imagenUrl || 'assets/placeholder-cuento.jpg'" alt="{{cuento.titulo}}" (load)="imagenCargada()" (error)="cargarImagenPlaceholder($event)">
     <div class="image-placeholder" *ngIf="cargandoImagen"></div>
-    <span class="cat-badge" *ngIf="cuento.categoria">{{ cuento.categoria }}</span>
   </div>
   <div class="cuento-content">
     <h3 class="cuento-title">{{ cuento.titulo }}</h3>
-    <div class="rating" *ngIf="cuento.rating">
-      <span>{{ getRatingStars(cuento.rating) }}</span>
+    <div class="rating" *ngIf="cuento.rating != null">
+      <span class="stars">{{ getRatingStars(cuento.rating) }}</span>
+      <span class="count" *ngIf="cuento.ratingCount as rc">({{ rc }})</span>
     </div>
     <p class="autor">Autor: {{ cuento.autor }}</p>
     <p class="excerpt">{{ cuento.descripcionCorta | slice:0:50 }}...</p>
-    <div class="precio"><span class="cuento-price">S/ {{ cuento.precio | number:'1.2-2' }}</span></div>
+    <div class="meta">
+      <span class="edad" *ngIf="cuento.edadRecomendada">Edad: {{ cuento.edadRecomendada }}+</span>
+      <span class="envio" *ngIf="cuento.envioGratis">🚚 Envío gratis desde S/ {{ minFreeShipping }}</span>
+    </div>
+    <div class="precio">
+      <span class="original" *ngIf="hasDiscount">S/ {{ cuento.precio | number:'1.2-2' }}</span>
+      <span class="final">S/ {{ precioFinal | number:'1.2-2' }}</span>
+    </div>
   </div>
 
   <div class="acciones">

--- a/src/app/components/cuento-card/cuento-card.component.scss
+++ b/src/app/components/cuento-card/cuento-card.component.scss
@@ -23,15 +23,36 @@
     animation: skeleton-loading 1.2s ease infinite;
   }
 
-  .cat-badge {
+  .badges {
     position: absolute;
-    bottom: 0.25rem;
-    left: 0.25rem;
-    background: #ffad60;
-    color: #a66e38;
-    padding: 0.1rem 0.4rem;
-    border-top-right-radius: 4px;
+    top: 0.5rem;
+    left: 0.5rem;
+    display: flex;
+    gap: 0.25rem;
+  }
+
+  .badge {
+    padding: 0.25rem 0.5rem;
+    border-radius: 4px;
     font-size: 0.75rem;
+    color: #fff;
+
+    &.category {
+      background: #ffad60;
+      color: #a66e38;
+    }
+
+    &.nuevo {
+      background: #96ceb4;
+    }
+
+    &.top {
+      background: #a66e38;
+    }
+
+    &.oferta {
+      background: #dc6a6a;
+    }
   }
 
   .cuento-content {
@@ -82,17 +103,45 @@
     margin: 0.25rem 0 0.5rem;
   }
 
-  .rating span {
-    color: #ffad60;
-    font-size: 0.9rem;
+  .rating {
+    .stars {
+      color: #ffad60;
+      font-size: 0.9rem;
+    }
+    .count {
+      margin-left: 0.25rem;
+      color: #4b3a2f;
+      font-size: 0.8rem;
+    }
   }
 
-  .cuento-price {
-    background: #ffad60;
-    color: #fff;
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-    font-size: 0.9rem;
+  .meta {
+    display: flex;
+    justify-content: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+
+    .edad,
+    .envio {
+      font-size: 0.8rem;
+      color: #4b3a2f;
+    }
+  }
+
+  .precio {
+    display: flex;
+    justify-content: center;
+    gap: 0.25rem;
+
+    .original {
+      text-decoration: line-through;
+      color: #a66e38;
+    }
+
+    .final {
+      font-weight: bold;
+      color: #a66e38;
+    }
   }
 
 
@@ -116,22 +165,6 @@
     }
   }
 
-  .badge {
-    position: absolute;
-    top: 0.5rem;
-    right: 0.5rem;
-    padding: 0.25rem 0.5rem;
-    border-radius: 4px;
-    font-size: 0.75rem;
-    color: #fff;
-    &.nuevo {
-      background: #96ceb4;
-    }
-    &.top {
-      background: #a66e38;
-    }
-    animation: none;
-  }
 }
 
 .cuento-card-imagen {

--- a/src/app/components/cuento-card/cuento-card.component.ts
+++ b/src/app/components/cuento-card/cuento-card.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy, OnInit
 import { Cuento } from '../../model/cuento.model'; // ajusta el path según tu estructura
 import { CartService } from '../../services/carrito.service';
 import { Router } from '@angular/router';
+import { environment } from '../../../environments/environment';
 
 @Component({
   selector: 'app-cuento-card',
@@ -19,6 +20,12 @@ export class CuentoCardComponent implements OnInit {
   cargandoImagen: boolean = true;
   isNuevo = false;
   badgeLabel = '';
+  minFreeShipping = environment.minFreeShipping;
+
+  /** Indica si el cuento posee un descuento válido */
+  get hasDiscount(): boolean {
+    return this.cuento.descuento !== undefined && this.cuento.descuento > 0;
+  }
 
   constructor(private cartService: CartService, private router: Router) {}
 
@@ -69,5 +76,13 @@ export class CuentoCardComponent implements OnInit {
 
   getRatingStars(rating: number): string {
     return '★★★★★'.slice(0, rating) + '☆☆☆☆☆'.slice(rating);
+  }
+
+  /** Precio final luego de aplicar el descuento */
+  get precioFinal(): number {
+    if (this.cuento.descuento && this.cuento.descuento > 0) {
+      return this.cuento.precio * (1 - this.cuento.descuento / 100);
+    }
+    return this.cuento.precio;
   }
 }

--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -1,6 +1,12 @@
 <div class="detalle-pagina">
   <div class="detalle-grid">
     <div class="hero">
+      <div class="badges">
+        <span class="badge category" *ngIf="cuento?.categoria">{{ cuento?.categoria }}</span>
+        <span class="badge nuevo" *ngIf="badgeLabel==='Nuevo'">Nuevo</span>
+        <span class="badge top" *ngIf="badgeLabel && badgeLabel!=='Nuevo'">{{ badgeLabel }}</span>
+        <span class="badge oferta" *ngIf="hasDiscount">-{{ cuento?.descuento }}% OFF</span>
+      </div>
       <div class="imagen-skeleton" *ngIf="cargandoImagen"></div>
       <img
         [appLazyLoad]="cuento?.imagenUrl || 'assets/placeholder-cuento.jpg'"
@@ -15,11 +21,18 @@
     <h1>{{ cuento?.titulo }}</h1>
     <div class="autor-precio">
       <h3>Autor: {{ cuento?.autor }}</h3>
-      <span class="precio">S/ {{ cuento?.precio | number:'1.2-2' }}</span>
+      <div class="precio">
+        <span class="original" *ngIf="hasDiscount">S/ {{ cuento?.precio | number:'1.2-2' }}</span>
+        <span class="final">S/ {{ precioFinal | number:'1.2-2' }}</span>
+      </div>
     </div>
-    <div class="envio-badge" *ngIf="cuento">🚚 Envío gratis desde S/ 50</div>
-    <div class="rating" aria-label="5 de 5">
-      <span>★★★★★</span>
+    <div class="meta">
+      <span class="edad" *ngIf="cuento?.edadRecomendada">Edad: {{ cuento?.edadRecomendada }}+</span>
+      <span class="envio" *ngIf="cuento?.envioGratis">🚚 Envío gratis desde S/ {{ minFreeShipping }}</span>
+    </div>
+    <div class="rating" *ngIf="cuento?.rating != null" [attr.aria-label]="cuento.rating + ' de 5'">
+      <span class="stars">{{ getRatingStars(cuento.rating) }}</span>
+      <span class="count" *ngIf="cuento?.ratingCount as rc">({{ rc }})</span>
     </div>
     <blockquote class="testimonial">
       “Un viaje mágico para toda la familia” – Carla R.
@@ -69,7 +82,7 @@
     </div>
   </section>
   <div class="sticky-cta" *ngIf="cuento">
-    <span class="price">S/ {{ cuento.precio | number:'1.2-2' }}</span>
+    <span class="price">S/ {{ precioFinal | number:'1.2-2' }}</span>
     <button class="btn btn-primary" (click)="agregarAlCarrito(); $event.stopPropagation()" [disabled]="!cuento.habilitado">Añadir al carrito</button>
   </div>
 </div>

--- a/src/app/components/detalle-cuento/detalle-cuento.component.scss
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.scss
@@ -60,10 +60,54 @@
   align-items: center;
 }
 
+.badges {
+  position: absolute;
+  top: 0.5rem;
+  left: 0.5rem;
+  display: flex;
+  gap: 0.25rem;
+}
+
+.badge {
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  color: #fff;
+
+  &.category {
+    background: #ffad60;
+    color: #a66e38;
+  }
+
+  &.nuevo {
+    background: #96ceb4;
+  }
+
+  &.top {
+    background: #a66e38;
+  }
+
+  &.oferta {
+    background: #dc6a6a;
+  }
+}
+
 .autor-precio .precio {
-  font-weight: bold;
-  color: #A66E38;
-  font-size: 2rem;
+  display: flex;
+  gap: 0.25rem;
+  align-items: baseline;
+
+  .original {
+    text-decoration: line-through;
+    color: #a66e38;
+    font-size: 1.5rem;
+  }
+
+  .final {
+    font-weight: bold;
+    color: #A66E38;
+    font-size: 2rem;
+  }
 }
 
 .envio-badge {
@@ -75,6 +119,18 @@
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
+}
+
+.meta {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+
+  .edad,
+  .envio {
+    font-size: 0.875rem;
+    color: #5d4037;
+  }
 }
 
 .sinopsis {
@@ -165,9 +221,17 @@
   }
 }
 
-.rating span {
-  color: #FFAD60;
-  font-size: 1.2rem;
+.rating {
+  .stars {
+    color: #FFAD60;
+    font-size: 1.2rem;
+  }
+
+  .count {
+    margin-left: 0.25rem;
+    font-size: 1rem;
+    color: #5d4037;
+  }
 }
 
 .testimonial {

--- a/src/app/components/detalle-cuento/detalle-cuento.component.ts
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.ts
@@ -5,6 +5,7 @@ import { Cuento } from './../../model/cuento.model';
 import { CartService } from '../../services/carrito.service';
 import { Location } from '@angular/common';
 import { Router } from '@angular/router';
+import { environment } from '../../../environments/environment';
 
 
 @Component({
@@ -18,6 +19,13 @@ export class DetalleCuentoComponent implements OnInit {
   relatedCuentos: Cuento[] = [];
   openTech = false;
   @ViewChild('carousel', { static: false }) carousel?: ElementRef<HTMLDivElement>;
+  minFreeShipping = environment.minFreeShipping;
+  isNuevo = false;
+  badgeLabel = '';
+  /** Indica si el cuento posee un descuento válido */
+  get hasDiscount(): boolean {
+    return this.cuento?.descuento !== undefined && this.cuento.descuento > 0;
+  }
   constructor(
     private route: ActivatedRoute,
     private cuentoService: CuentoService,
@@ -31,6 +39,11 @@ export class DetalleCuentoComponent implements OnInit {
     if (id) {
       this.cuentoService.getCuentoById(+id).subscribe(data => {
         this.cuento = data;
+        if (this.cuento?.fechaIngreso) {
+          const diff = (Date.now() - new Date(this.cuento.fechaIngreso).getTime()) / (1000 * 3600 * 24);
+          this.isNuevo = diff <= 30;
+        }
+        this.badgeLabel = this.cuento.badge || (this.isNuevo ? 'Nuevo' : '');
       });
       this.cuentoService.obtenerCuentos().subscribe(cuentos => {
         this.relatedCuentos = cuentos.filter(c => c.id !== +id).slice(0, 8);
@@ -75,6 +88,22 @@ export class DetalleCuentoComponent implements OnInit {
 
   volver() {
   this.location.back();
+  }
+
+  /** Devuelve el string de estrellas según la valoración */
+  getRatingStars(rating: number): string {
+    return '★★★★★'.slice(0, rating) + '☆☆☆☆☆'.slice(rating);
+  }
+
+  /** Calcula el precio final con descuento */
+  get precioFinal(): number {
+    if (!this.cuento) {
+      return 0;
+    }
+    if (this.cuento.descuento && this.cuento.descuento > 0) {
+      return this.cuento.precio * (1 - this.cuento.descuento / 100);
+    }
+    return this.cuento.precio;
   }
 
   /** Mensaje de stock con advertencia cuando quedan pocas unidades */

--- a/src/app/model/cuento.model.ts
+++ b/src/app/model/cuento.model.ts
@@ -17,4 +17,10 @@ export interface Cuento {
   categoria?: string;  // Etiqueta emocional (Aventura, Didáctico, Clásico)
   rating?: number;     // Valoración de 1 a 5
   badge?: string;      // Promoción: Nuevo, Top Ventas, Recomendado
+  /** Cantidad de reseñas que respaldan el rating */
+  ratingCount?: number;
+  /** Porcentaje de descuento (0-100) */
+  descuento?: number;
+  /** Indica si el cuento califica para envío gratis */
+  envioGratis?: boolean;
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,7 @@
 export const environment = {
   production: true,
   apiBaseUrl: 'https://cuentos-killa-be-1.onrender.com/api',
-  sentryDsn: 'https://206c3de140ffe2f6be2200ed522250b1@o4509612268912640.ingest.us.sentry.io/4509612333727744'
+  sentryDsn: 'https://206c3de140ffe2f6be2200ed522250b1@o4509612268912640.ingest.us.sentry.io/4509612333727744',
+  /** Monto mínimo para obtener envío gratuito */
+  minFreeShipping: 50
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,7 @@
 export const environment = {
   production: false,
   apiBaseUrl: 'http://localhost:8080/api',
-  sentryDsn: 'https://206c3de140ffe2f6be2200ed522250b1@o4509612268912640.ingest.us.sentry.io/4509612333727744'
+  sentryDsn: 'https://206c3de140ffe2f6be2200ed522250b1@o4509612268912640.ingest.us.sentry.io/4509612333727744',
+  /** Monto mínimo para obtener envío gratuito */
+  minFreeShipping: 50
 };


### PR DESCRIPTION
## Summary
- add free shipping env variable
- extend cuento model with offer and rating info
- show promotional badges on cuento card and detail
- display rating count and shipping meta
- show price with discount calculation
- fix template checks

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686914d05f748327b2d86c066e8588b2