### PR TITLE
Update Sentry init with new DSN

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@angular/platform-server": "^18.0.0",
         "@angular/router": "^18.0.0",
         "@angular/ssr": "^18.0.0",
-        "@sentry/angular-ivy": "^7.120.3",
+        "@sentry/angular": "^7.120.3",
         "@sentry/tracing": "^7.120.3",
         "chart.js": "^4.4.0",
         "date-fns": "^2.30.0",
@@ -4251,9 +4251,9 @@
         "node": ">=8"
       }
     },
-    "node_modules/@sentry/angular-ivy": {
+    "node_modules/@sentry/angular": {
       "version": "7.120.3",
-      "resolved": "https://registry.npmjs.org/@sentry/angular-ivy/-/angular-ivy-7.120.3.tgz",
+      "resolved": "https://registry.npmjs.org/@sentry/angular/-/angular-7.120.3.tgz",
       "integrity": "sha512-vQ1padfnPgXUltcaTcMm5R2OTQbjaUXr+rq2NmCNtk7fTcK9mt4T3UDPup4z2WHI+I/H8xYl8CgspnOOL/1fwQ==",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "chart.js": "^4.4.0",
     "ng2-charts": "^4.0.0",
     "date-fns": "^2.30.0",
-    "@sentry/angular-ivy": "^7.120.3",
+    "@sentry/angular": "^7.120.3",
     "@sentry/tracing": "^7.120.3"
   },
   "devDependencies": {

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -8,7 +8,7 @@ import { provideAnimationsAsync } from '@angular/platform-browser/animations/asy
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { authInterceptor } from './services/auth.interceptor';
 import { ThemeService } from './services/theme.service';
-import * as Sentry from '@sentry/angular-ivy';
+import * as Sentry from '@sentry/angular';
 
 
 

--- a/src/environments/environment-local.ts
+++ b/src/environments/environment-local.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: false,
   apiBaseUrl: 'http://localhost:8080/api',
-  sentryDsn: 'https://206c3de140ffe2f6be2200ed522250b1@o4509612268912640.ingest.us.sentry.io/4509612333727744'};
+  sentryDsn: 'https://bd1fbbf709cf13f839ce491feec0a1e9@o4509612268912640.ingest.us.sentry.io/4509616124002304'};

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
   apiBaseUrl: 'https://cuentos-killa-be-1.onrender.com/api',
-  sentryDsn: 'https://206c3de140ffe2f6be2200ed522250b1@o4509612268912640.ingest.us.sentry.io/4509612333727744'
+  sentryDsn: 'https://bd1fbbf709cf13f839ce491feec0a1e9@o4509612268912640.ingest.us.sentry.io/4509616124002304'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
   apiBaseUrl: 'http://localhost:8080/api',
-  sentryDsn: 'https://206c3de140ffe2f6be2200ed522250b1@o4509612268912640.ingest.us.sentry.io/4509612333727744'
+  sentryDsn: 'https://bd1fbbf709cf13f839ce491feec0a1e9@o4509612268912640.ingest.us.sentry.io/4509616124002304'
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,19 +1,18 @@
 import { bootstrapApplication } from '@angular/platform-browser';
+import * as Sentry from '@sentry/angular';
+
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
-import * as Sentry from '@sentry/angular-ivy';
-import { BrowserTracing } from '@sentry/tracing';
 import { environment } from './environments/environment';
 
 Sentry.init({
   dsn: environment.sentryDsn,
-  integrations: [
-    new BrowserTracing({
-      routingInstrumentation: Sentry.routingInstrumentation,
-    }),
-  ],
+  // Send default personally identifiable information
   sendDefaultPii: true,
+  integrations: [Sentry.browserTracingIntegration()],
+  // Capture all traces in development. Adjust in production as needed.
   tracesSampleRate: 1.0,
+  tracePropagationTargets: ['localhost', /^https:\/\/yourserver\.io\/api/],
 });
 
 bootstrapApplication(AppComponent, appConfig)


### PR DESCRIPTION
## Summary
- update Sentry DSN in all environment files
- switch to `@sentry/angular` imports and new init API
- adjust package files for the new Sentry package

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869232049248327bda17c235b8bf1a8