### PR TITLE
Fix rating template build error

### DIFF
--- a/src/app/components/cuento-card/cuento-card.component.html
+++ b/src/app/components/cuento-card/cuento-card.component.html
@@ -12,7 +12,7 @@
   <div class="cuento-content">
     <h3 class="cuento-title">{{ cuento.titulo }}</h3>
     <div class="rating" *ngIf="cuento.rating != null">
-      <span class="stars">{{ getRatingStars(cuento.rating ?? 0) }}</span>
+      <span class="stars">{{ getRatingStars(cuento.rating) }}</span>
       <span class="count" *ngIf="cuento.ratingCount as rc">({{ rc }})</span>
     </div>
     <p class="autor">Autor: {{ cuento.autor }}</p>

--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -30,8 +30,8 @@
       <span class="edad" *ngIf="cuento?.edadRecomendada">Edad: {{ cuento?.edadRecomendada }}+</span>
       <span class="envio" *ngIf="cuento?.envioGratis">🚚 Envío gratis desde S/ {{ minFreeShipping }}</span>
     </div>
-    <div class="rating" *ngIf="cuento?.rating != null" [attr.aria-label]="(cuento?.rating ?? 0) + ' de 5'">
-      <span class="stars">{{ getRatingStars(cuento?.rating ?? 0) }}</span>
+    <div class="rating" *ngIf="cuento?.rating != null" [attr.aria-label]="cuento!.rating + ' de 5'">
+      <span class="stars">{{ getRatingStars(cuento!.rating) }}</span>
       <span class="count" *ngIf="cuento?.ratingCount as rc">({{ rc }})</span>
     </div>
     <blockquote class="testimonial">


### PR DESCRIPTION
## Summary
- adjust rating template to use non-null assertion for type safety

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*
- `npm run vercel-build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697bf3db8c8327a129373a0965311b