### PR TITLE
Fix rating template build error

### DIFF
--- a/src/app/components/cuento-card/cuento-card.component.html
+++ b/src/app/components/cuento-card/cuento-card.component.html
@@ -12,7 +12,7 @@
   <div class="cuento-content">
     <h3 class="cuento-title">{{ cuento.titulo }}</h3>
     <div class="rating" *ngIf="cuento.rating != null">
-      <span class="stars">{{ getRatingStars(cuento.rating ?? 0) }}</span>
+      <span class="stars">{{ getRatingStars(cuento.rating) }}</span>
       <span class="count" *ngIf="cuento.ratingCount as rc">({{ rc }})</span>
     </div>
     <p class="autor">Autor: {{ cuento.autor }}</p>


### PR DESCRIPTION
## Summary
- adjust rating template to avoid undefined argument

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*
- `npm run vercel-build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697bf3db8c8327a129373a0965311b