### PR TITLE
Show cuentos on home page

### DIFF
--- a/src/app/components/pages/Home/home.component.html
+++ b/src/app/components/pages/Home/home.component.html
@@ -1,3 +1,3 @@
 <h2>Bienvenido a Cuentos de Killa</h2>
 <app-hero-banner></app-hero-banner>
-<app-cuentos-grid></app-cuentos-grid>
+<app-cuentos-page></app-cuentos-page>

--- a/src/app/components/pages/Home/home.module.ts
+++ b/src/app/components/pages/Home/home.module.ts
@@ -4,6 +4,7 @@ import { HomeRoutingModule } from './home-routing.module';
 import { HeroBannerComponent } from '../../hero-banner/hero-banner.component';
 import { CuentosGridComponent } from '../../cuentos-grid/cuentos-grid.component';
 import { HomeComponent } from './home.component';
+import { CuentosModule } from '../cuentos/cuentos.module';
 import { MatCardModule } from '@angular/material/card';
 import { SharedModule } from './../../shared.module';
 
@@ -13,7 +14,9 @@ import { SharedModule } from './../../shared.module';
   imports: [
     CommonModule,
     HomeRoutingModule,
-    MatCardModule,SharedModule
+    MatCardModule,
+    SharedModule,
+    CuentosModule
   ],
 })
 export class HomeModule {}


### PR DESCRIPTION
## Summary
- embed `CuentosComponent` in the home page so cuento-card appears
- import `CuentosModule` in HomeModule

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869b315491483279e2f50816a4357f3