### PR TITLE
Initialize Chart.js

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import * as Sentry from '@sentry/angular';
+import { Chart, registerables } from 'chart.js';
 
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
@@ -14,6 +15,8 @@ Sentry.init({
   tracesSampleRate: 1.0,
   tracePropagationTargets: ['localhost', 'cuentos-killa-fe.vercel.app'],
 });
+
+Chart.register(...registerables);
 
 bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));


### PR DESCRIPTION
## Summary
- register Chart.js before bootstrapping Angular app

## Testing
- `npm install` *(fails: cannot access registry)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5dd4a9a88327a15aea1fcd9c843b