### PR TITLE
Implement voucher review modal

### DIFF
--- a/src/app/components/app-modal/modal.component.html
+++ b/src/app/components/app-modal/modal.component.html
@@ -1,0 +1,14 @@
+<div class="overlay">
+  <div class="modal">
+    <header class="modal-header">
+      <h3>{{ title }}</h3>
+      <button class="close-btn" (click)="onClose()">&#x2715;</button>
+    </header>
+    <div class="modal-body">
+      <ng-content></ng-content>
+    </div>
+    <footer class="modal-footer">
+      <ng-content select="[modal-footer]"></ng-content>
+    </footer>
+  </div>
+</div>

--- a/src/app/components/app-modal/modal.component.scss
+++ b/src/app/components/app-modal/modal.component.scss
@@ -1,0 +1,45 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal {
+  background: #fff;
+  border-radius: 8px;
+  max-width: 90%;
+  padding: 1rem;
+}
+
+.modal-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.modal-body img {
+  max-width: 100%;
+  max-height: 400px;
+}
+
+.modal-footer {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}

--- a/src/app/components/app-modal/modal.component.ts
+++ b/src/app/components/app-modal/modal.component.ts
@@ -1,0 +1,18 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-modal',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './modal.component.html',
+  styleUrls: ['./modal.component.scss']
+})
+export class ModalComponent {
+  @Input() title = '';
+  @Output() close = new EventEmitter<void>();
+
+  onClose(): void {
+    this.close.emit();
+  }
+}

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
@@ -16,6 +16,7 @@
         <th>Estado Pago</th>
         <th>Tipo Pago</th>
         <th>Total</th>
+        <th>Acción</th>
       </tr>
     </thead>
     <tbody>
@@ -29,7 +30,22 @@
         <td>{{ pedido.estado }}</td>
         <td>{{ pedido.tipoPago || 'N/A' }}</td>
         <td>{{ pedido.total | currency:'USD':'symbol':'1.2-2' }}</td>
+        <td>
+          <button
+            *ngIf="pedido.estado === 'PAGO_PENDIENTE' && (pedido.tipoPago === 'YAPE' || pedido.tipoPago === 'PLIN')"
+            class="btn btn-primary"
+            (click)="abrirModal(pedido)">
+            Ver Voucher
+          </button>
+        </td>
       </tr>
     </tbody>
   </table>
 </div>
+<app-modal *ngIf="selectedPedido" [title]="'Voucher Pedido #' + (selectedPedido?.Id || selectedPedido?.id)" (close)="cerrarModal()">
+  <img *ngIf="voucherImg" [src]="voucherImg" alt="Voucher" />
+  <div modal-footer>
+    <button class="btn btn-success" (click)="validarPago()" [disabled]="processing">Validar Pago</button>
+    <button class="btn btn-danger" (click)="rechazarPago()" [disabled]="processing">Rechazar Pago</button>
+  </div>
+</app-modal>

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
@@ -5,8 +5,6 @@ import { Pedido } from '../../../../model/pedido.model';
 
 @Component({
   selector: 'app-admin-pedidos',
-  // standalone: true,
-  // imports: [CommonModule],
   templateUrl: './admin-pedidos.component.html',
   styleUrls: ['./admin-pedidos.component.scss']
 })
@@ -14,6 +12,9 @@ export class AdminPedidosComponent implements OnInit {
   pedidos: Pedido[] = [];
   isLoading = true;
   errorMensaje: string | null = null;
+  selectedPedido: Pedido | null = null;
+  voucherImg: string | null = null;
+  processing = false;
 
   constructor(private pedidoService: PedidoService) {}
 
@@ -29,6 +30,59 @@ export class AdminPedidosComponent implements OnInit {
         console.error('Error fetching orders:', err);
         this.errorMensaje = 'No se pudieron cargar los pedidos';
         this.isLoading = false;
+      }
+    });
+  }
+
+  abrirModal(pedido: Pedido): void {
+    this.selectedPedido = pedido;
+    const id = pedido.Id || pedido.id || 0;
+    this.pedidoService.getVoucher(id).subscribe({
+      next: blob => {
+        this.voucherImg = URL.createObjectURL(blob);
+      },
+      error: err => console.error('Error fetching voucher', err)
+    });
+  }
+
+  cerrarModal(): void {
+    if (this.voucherImg) {
+      URL.revokeObjectURL(this.voucherImg);
+    }
+    this.selectedPedido = null;
+    this.voucherImg = null;
+    this.processing = false;
+  }
+
+  validarPago(): void {
+    if (!this.selectedPedido) return;
+    this.processing = true;
+    const id = this.selectedPedido.Id || this.selectedPedido.id || 0;
+    this.pedidoService.validateVoucher(id).subscribe({
+      next: () => {
+        this.selectedPedido!.estado = 'PAGO_VERIFICADO';
+        this.cerrarModal();
+      },
+      error: err => {
+        console.error('Error validating voucher', err);
+        this.processing = false;
+      }
+    });
+  }
+
+  rechazarPago(): void {
+    if (!this.selectedPedido) return;
+    const motivo = prompt('Motivo de rechazo (opcional)') || '';
+    this.processing = true;
+    const id = this.selectedPedido.Id || this.selectedPedido.id || 0;
+    this.pedidoService.rejectVoucher(id, motivo).subscribe({
+      next: () => {
+        this.selectedPedido!.estado = 'PAGO_RECHAZADO';
+        this.cerrarModal();
+      },
+      error: err => {
+        console.error('Error rejecting voucher', err);
+        this.processing = false;
       }
     });
   }

--- a/src/app/components/pages/admin/admin.module.ts
+++ b/src/app/components/pages/admin/admin.module.ts
@@ -16,6 +16,7 @@ import { ConfigCategoryFormComponent } from './admin-config/config-category-form
 import { ConfigItemsComponent } from './admin-config/config-items.component';
 import { ConfigItemFormComponent } from './admin-config/config-item-form.component';
 import { SharedModule } from "../../shared.module";
+import { ModalComponent } from '../../app-modal/modal.component';
 
 // import { SharedModule } from '../../shared.module'; 
 
@@ -62,7 +63,8 @@ const routes: Routes = [
     RouterModule,
     RouterModule.forChild(routes),
     SharedModule,
-    AdminLayoutComponent
+    AdminLayoutComponent,
+    ModalComponent
   ]
 })
 export class AdminModule {}

--- a/src/app/model/pedido.model.ts
+++ b/src/app/model/pedido.model.ts
@@ -23,4 +23,5 @@ export interface Pedido {
   tipoPago?: string;
   userId: number;
   correoUsuario: string;
+  voucherUrl?: string;
 }

--- a/src/app/services/pedido.service.ts
+++ b/src/app/services/pedido.service.ts
@@ -39,4 +39,16 @@ export class PedidoService {
   downloadInvoice(id: number): Observable<Blob> {
     return this.http.get(`${this.apiUrl}/${id}/pdf`, { responseType: 'blob' });
   }
+
+  getVoucher(id: number): Observable<Blob> {
+    return this.http.get(`${this.apiUrl}/${id}/voucher`, { responseType: 'blob' });
+  }
+
+  validateVoucher(id: number): Observable<any> {
+    return this.http.post(`${this.apiUrl}/${id}/validate-voucher`, {}, { withCredentials: true });
+  }
+
+  rejectVoucher(id: number, motivo: string): Observable<any> {
+    return this.http.post(`${this.apiUrl}/${id}/reject-voucher`, { motivo }, { withCredentials: true });
+  }
 }

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -44,3 +44,13 @@
   color: var(--btn-disabled-text);
   cursor: not-allowed;
 }
+
+.btn-success {
+  background-color: #28a745;
+  color: #fff;
+}
+
+.btn-danger {
+  background-color: #dc3545;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add success and danger button styles
- create reusable modal component
- extend order model and service for voucher validation
- show 'Ver Voucher' button in admin orders and open modal

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5e363b7883279205f8d0bb68eea8