### PR TITLE
Disable prerender to fix build error

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -37,7 +37,7 @@
             ],
             "scripts": [],
             "server": "src/main.server.ts",
-            "prerender": true,
+            "prerender": false,
             "ssr": {
               "entry": "server.ts"
             }


### PR DESCRIPTION
## Summary
- disable prerender option in `angular.json` to avoid undefined `routes`

## Testing
- `npm test -- --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a61fe30548327bdef0f69d8b730e0