### PR TITLE
Add rejection reason dialog

### DIFF
--- a/src/app/components/input-dialog/input-dialog.component.html
+++ b/src/app/components/input-dialog/input-dialog.component.html
@@ -1,0 +1,10 @@
+<div class="overlay">
+  <div class="dialog">
+    <p>{{ message }}</p>
+    <textarea [(ngModel)]="reason" placeholder="Motivo" rows="3"></textarea>
+    <div class="buttons">
+      <button class="confirm" (click)="onConfirm()">Aceptar</button>
+      <button class="cancel" (click)="onCancel()">Cancelar</button>
+    </div>
+  </div>
+</div>

--- a/src/app/components/input-dialog/input-dialog.component.scss
+++ b/src/app/components/input-dialog/input-dialog.component.scss
@@ -1,0 +1,51 @@
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.dialog {
+  background: white;
+  padding: 1.5rem;
+  border-radius: 8px;
+  text-align: center;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+  width: 90%;
+  max-width: 400px;
+}
+
+textarea {
+  width: 100%;
+  margin-top: 1rem;
+}
+
+.buttons {
+  margin-top: 1rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+button.confirm {
+  background-color: #28a745;
+  color: #fff;
+}
+
+button.cancel {
+  background-color: #dc3545;
+  color: #fff;
+}

--- a/src/app/components/input-dialog/input-dialog.component.spec.ts
+++ b/src/app/components/input-dialog/input-dialog.component.spec.ts
@@ -1,0 +1,37 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { InputDialogComponent } from './input-dialog.component';
+
+describe('InputDialogComponent', () => {
+  let component: InputDialogComponent;
+  let fixture: ComponentFixture<InputDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [InputDialogComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(InputDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should emit confirm with reason', () => {
+    spyOn(component.confirm, 'emit');
+    component.reason = 'test reason';
+    const btn = fixture.debugElement.query(By.css('button.confirm'));
+    btn.triggerEventHandler('click');
+    expect(component.confirm.emit).toHaveBeenCalledWith('test reason');
+  });
+
+  it('should emit cancel on cancel button click', () => {
+    spyOn(component.cancel, 'emit');
+    const btn = fixture.debugElement.query(By.css('button.cancel'));
+    btn.triggerEventHandler('click');
+    expect(component.cancel.emit).toHaveBeenCalled();
+  });
+});

--- a/src/app/components/input-dialog/input-dialog.component.ts
+++ b/src/app/components/input-dialog/input-dialog.component.ts
@@ -1,0 +1,25 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-input-dialog',
+  standalone: true,
+  imports: [CommonModule, FormsModule],
+  templateUrl: './input-dialog.component.html',
+  styleUrls: ['./input-dialog.component.scss']
+})
+export class InputDialogComponent {
+  @Input() message = '';
+  reason = '';
+  @Output() confirm = new EventEmitter<string>();
+  @Output() cancel = new EventEmitter<void>();
+
+  onConfirm(): void {
+    this.confirm.emit(this.reason);
+  }
+
+  onCancel(): void {
+    this.cancel.emit();
+  }
+}

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
@@ -49,3 +49,9 @@
     <button class="btn btn-danger" (click)="rechazarPago()" [disabled]="processing">Rechazar Pago</button>
   </div>
 </app-modal>
+<app-input-dialog
+  *ngIf="showReasonDialog"
+  [message]="'Motivo de rechazo (opcional)'"
+  (confirm)="confirmarRechazo($event)"
+  (cancel)="cancelarRechazo()">
+</app-input-dialog>

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.spec.ts
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.spec.ts
@@ -1,16 +1,22 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AdminPedidosComponent } from './admin-pedidos.component';
+import { PedidoService } from '../../../../services/pedido.service';
+import { InputDialogComponent } from '../../../input-dialog/input-dialog.component';
+import { ModalComponent } from '../../../app-modal/modal.component';
 
 describe('AdminPedidosComponent', () => {
   let component: AdminPedidosComponent;
   let fixture: ComponentFixture<AdminPedidosComponent>;
+  let pedidoServiceSpy: jasmine.SpyObj<PedidoService>;
 
   beforeEach(async () => {
+    pedidoServiceSpy = jasmine.createSpyObj('PedidoService', ['rejectVoucher']);
+
     await TestBed.configureTestingModule({
-      imports: [AdminPedidosComponent]
-    })
-    .compileComponents();
+      imports: [AdminPedidosComponent, InputDialogComponent, ModalComponent],
+      providers: [{ provide: PedidoService, useValue: pedidoServiceSpy }]
+    }).compileComponents();
 
     fixture = TestBed.createComponent(AdminPedidosComponent);
     component = fixture.componentInstance;
@@ -19,5 +25,21 @@ describe('AdminPedidosComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should open dialog on rechazarPago and call service on confirm', () => {
+    component.selectedPedido = { id: 1 } as any;
+    component.rechazarPago();
+    expect(component.showReasonDialog).toBeTrue();
+    component.confirmarRechazo('no valido');
+    expect(pedidoServiceSpy.rejectVoucher).toHaveBeenCalledWith(1, 'no valido');
+  });
+
+  it('should not call service when canceling', () => {
+    component.selectedPedido = { id: 2 } as any;
+    component.rechazarPago();
+    component.cancelarRechazo();
+    expect(component.showReasonDialog).toBeFalse();
+    expect(pedidoServiceSpy.rejectVoucher).not.toHaveBeenCalled();
   });
 });

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
@@ -15,6 +15,7 @@ export class AdminPedidosComponent implements OnInit {
   selectedPedido: Pedido | null = null;
   voucherImg: string | null = null;
   processing = false;
+  showReasonDialog = false;
 
   constructor(private pedidoService: PedidoService) {}
 
@@ -72,7 +73,12 @@ export class AdminPedidosComponent implements OnInit {
 
   rechazarPago(): void {
     if (!this.selectedPedido) return;
-    const motivo = prompt('Motivo de rechazo (opcional)') || '';
+    this.showReasonDialog = true;
+  }
+
+  confirmarRechazo(motivo: string): void {
+    if (!this.selectedPedido) return;
+    this.showReasonDialog = false;
     this.processing = true;
     const id = this.selectedPedido.Id || this.selectedPedido.id || 0;
     this.pedidoService.rejectVoucher(id, motivo).subscribe({
@@ -85,5 +91,9 @@ export class AdminPedidosComponent implements OnInit {
         this.processing = false;
       }
     });
+  }
+
+  cancelarRechazo(): void {
+    this.showReasonDialog = false;
   }
 }

--- a/src/app/components/pages/admin/admin.module.ts
+++ b/src/app/components/pages/admin/admin.module.ts
@@ -11,6 +11,7 @@ import { AdminPedidosComponent } from './admin-pedidos/admin-pedidos.component';
 import { AdminUsuariosComponent } from './admin-usuarios/admin-usuarios.component';
 import { CuentoFormComponent } from './cuento-form/cuento-form.component';
 import { ConfirmDialogComponent } from '../../confirm-dialog/confirm-dialog.component';
+import { InputDialogComponent } from '../../input-dialog/input-dialog.component';
 import { ConfigCategoriesComponent } from './admin-config/config-categories.component';
 import { ConfigCategoryFormComponent } from './admin-config/config-category-form.component';
 import { ConfigItemsComponent } from './admin-config/config-items.component';
@@ -64,7 +65,8 @@ const routes: Routes = [
     RouterModule.forChild(routes),
     SharedModule,
     AdminLayoutComponent,
-    ModalComponent
+    ModalComponent,
+    InputDialogComponent
   ]
 })
 export class AdminModule {}


### PR DESCRIPTION
## Summary
- create a reusable `InputDialogComponent` for entering a reason
- integrate the dialog in admin payments page
- send reason to the service when confirming rejection
- provide AdminModule import for the new dialog
- test dialog behavior in admin pedidos

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aadee15808327b32214e3c05939e9