### PR TITLE
Add responsive card view for admin orders

### DIFF
--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
@@ -4,7 +4,7 @@
   <div *ngIf="isLoading">Cargando pedidos...</div>
   <div *ngIf="errorMensaje">{{ errorMensaje }}</div>
 
-  <table *ngIf="!isLoading && !errorMensaje">
+  <table *ngIf="!isLoading && !errorMensaje && !isMobile">
     <thead>
       <tr>
         <th>ID</th>
@@ -41,6 +41,35 @@
       </tr>
     </tbody>
   </table>
+
+  <ng-container *ngIf="!isLoading && !errorMensaje && isMobile">
+    <div class="pedido-cards">
+      <div
+        class="pedido-card"
+        *ngFor="let pedido of pedidos"
+        [class.pendiente]="pedido.estado === 'PAGO_PENDIENTE'"
+      >
+        <div><strong>ID:</strong> {{ pedido.Id || pedido.id }}</div>
+        <div><strong>Fecha/Hora:</strong> {{ pedido.fecha | date:'dd/MM/yyyy HH:mm' }}</div>
+        <div><strong>Nombre:</strong> {{ pedido.nombre }}</div>
+        <div><strong>Correo:</strong> {{ pedido.correo }}</div>
+        <div><strong>Dirección:</strong> {{ pedido.direccion }}</div>
+        <div><strong>Teléfono:</strong> {{ pedido.telefono }}</div>
+        <div><strong>Estado Pago:</strong> {{ pedido.estado }}</div>
+        <div><strong>Tipo Pago:</strong> {{ pedido.tipoPago || 'N/A' }}</div>
+        <div><strong>Total:</strong> {{ pedido.total | currency:'USD':'symbol':'1.2-2' }}</div>
+        <div class="acciones">
+          <button
+            *ngIf="pedido.estado === 'PAGO_ENVIADO'"
+            class="btn btn-primary"
+            (click)="abrirModal(pedido)"
+          >
+            Ver Voucher
+          </button>
+        </div>
+      </div>
+    </div>
+  </ng-container>
 </div>
 <app-modal *ngIf="selectedPedido" [title]="'Voucher Pedido #' + (selectedPedido!.Id || selectedPedido!.id)" (close)="cerrarModal()">
   <img *ngIf="voucherImg" [src]="voucherImg" alt="Voucher" />

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.scss
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.scss
@@ -46,8 +46,24 @@
 
 @media (max-width: 600px) {
   table {
-    display: block;
-    overflow-x: auto;
-    white-space: nowrap;
+    display: none;
+  }
+
+  .pedido-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .pedido-card {
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    background: #fff;
+    padding: 1rem;
+
+    .acciones {
+      margin-top: 0.5rem;
+      text-align: right;
+    }
   }
 }

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PedidoService } from '../../../../services/pedido.service';
 import { Pedido } from '../../../../model/pedido.model';
@@ -15,10 +15,17 @@ export class AdminPedidosComponent implements OnInit {
   selectedPedido: Pedido | null = null;
   voucherImg: string | null = null;
   processing = false;
+  isMobile = false;
 
   constructor(private pedidoService: PedidoService) {}
 
+  @HostListener('window:resize')
+  onResize() {
+    this.isMobile = window.innerWidth <= 600;
+  }
+
   ngOnInit(): void {
+    this.onResize();
     this.pedidoService.getOrders().subscribe({
       next: data => {
          this.pedidos = data


### PR DESCRIPTION
## Summary
- show a mobile card view of pedidos when screen width is small
- hide table on small screens and keep voucher actions within cards
- update styling for the card layout

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aadf4e64483278a4f01f9efb77d8c