### PR TITLE
Fix voucher image loading in admin orders

### DIFF
--- a/src/app/services/pedido.service.ts
+++ b/src/app/services/pedido.service.ts
@@ -41,7 +41,10 @@ export class PedidoService {
   }
 
   getVoucher(id: number): Observable<Blob> {
-    return this.http.get(`${this.apiUrl}/${id}/voucher`, { responseType: 'blob' });
+    return this.http.get(`${this.apiUrl}/${id}/voucher`, {
+      responseType: 'blob',
+      withCredentials: true
+    });
   }
 
   validateVoucher(id: number): Observable<any> {


### PR DESCRIPTION
## Summary
- ensure voucher requests include cookies by setting `withCredentials: true`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aeb700d788327b0313b15a5fce858