### PR TITLE
Fix duplicate InputDialogComponent import

### DIFF
--- a/src/app/components/pages/admin/admin.module.ts
+++ b/src/app/components/pages/admin/admin.module.ts
@@ -18,7 +18,6 @@ import { ConfigItemsComponent } from './admin-config/config-items.component';
 import { ConfigItemFormComponent } from './admin-config/config-item-form.component';
 import { SharedModule } from "../../shared.module";
 import { ModalComponent } from '../../app-modal/modal.component';
-import { InputDialogComponent } from '../../input-dialog/input-dialog.component';
 
 // import { SharedModule } from '../../shared.module'; 
 


### PR DESCRIPTION
## Summary
- remove duplicate `InputDialogComponent` import in `AdminModule`

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aeef97904832782cd63455a0afe1e