### PR TITLE
Add button styles in admin config tables

### DIFF
--- a/src/app/components/pages/admin/admin-config/config-categories.component.html
+++ b/src/app/components/pages/admin/admin-config/config-categories.component.html
@@ -20,9 +20,9 @@
         <td>{{ c.name }}</td>
         <td>{{ c.createdAt | date:'short' }}</td>
         <td class="acciones">
-          <button (click)="editar(c.id1!)">Editar</button>
-          <button (click)="eliminar(c.id1!)">Eliminar</button>
-          <button (click)="verItems(c.id1!)">Ver ítems</button>
+          <button class="btn btn-primary" (click)="editar(c.id1!)">Editar</button>
+          <button class="btn btn-danger" (click)="eliminar(c.id1!)">Eliminar</button>
+          <button class="btn btn-secondary" (click)="verItems(c.id1!)">Ver ítems</button>
         </td>
       </tr>
     </tbody>

--- a/src/app/components/pages/admin/admin-config/config-items.component.html
+++ b/src/app/components/pages/admin/admin-config/config-items.component.html
@@ -20,8 +20,8 @@
         <td>{{ i.label }}</td>
         <td>{{ i.sensitive ? 'Sí' : 'No' }}</td>
         <td class="acciones">
-          <button (click)="editar(i.id2)">Editar</button>
-          <button (click)="eliminar(i.id2)">Eliminar</button>
+          <button class="btn btn-primary" (click)="editar(i.id2)">Editar</button>
+          <button class="btn btn-danger" (click)="eliminar(i.id2)">Eliminar</button>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
## Summary
- make action buttons in admin config categories/items use Bootstrap-like `.btn` styles

## Testing
- `npm test` *(fails: no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_686b19289c4083278d44f3bd42f3ea11