### PR TITLE
Update cuento form buttons

### DIFF
--- a/src/app/components/pages/admin/cuento-form/cuento-form.html
+++ b/src/app/components/pages/admin/cuento-form/cuento-form.html
@@ -53,8 +53,8 @@
     <div class="error-mensaje" *ngIf="errorMensaje">{{ errorMensaje }}</div>
 
     <div class="acciones">
-      <button type="submit" class="aceptar">{{ isEditMode ? 'Actualizar' : 'Crear' }}</button>
-      <button type="button" class="cancelar" (click)="cancelar()">Cancelar</button>
+      <button type="submit" class="btn btn-primary">{{ isEditMode ? 'Actualizar' : 'Crear' }}</button>
+      <button type="button" class="btn btn-danger" (click)="cancelar()">Cancelar</button>
     </div>
   </form>
 </div>

--- a/src/app/components/pages/admin/cuento-form/cuento-form.scss
+++ b/src/app/components/pages/admin/cuento-form/cuento-form.scss
@@ -45,15 +45,6 @@
       cursor: pointer;
     }
 
-    .aceptar {
-      background-color: #28a745;
-      color: #fff;
-    }
-
-    .cancelar {
-      background-color: #dc3545;
-      color: #fff;
-    }
   }
 }
 


### PR DESCRIPTION
## Summary
- use global `btn` styles for the admin cuento form buttons
- remove local color overrides so styles come from global classes

## Testing
- `npm test` *(fails: `ng` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b192b45f08327af14d1d38fad64cc