### PR TITLE
Remove custom add-button style

### DIFF
--- a/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.html
+++ b/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.html
@@ -2,7 +2,7 @@
   <h2>Gestión de Cuentos</h2>
 
   <div class="admin-acciones-globales">
-    <button (click)="abrirModalAgregarCuento()" class="boton-agregar">
+    <button (click)="abrirModalAgregarCuento()" class="btn btn-primary">
       <i class="fas fa-plus"></i> Agregar Nuevo Cuento
     </button>
   </div>

--- a/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.scss
+++ b/src/app/components/pages/admin/admin-cuentos/admin-cuentos.component.scss
@@ -13,30 +13,6 @@
   .admin-acciones-globales {
     margin-bottom: 25px;
     text-align: right;
-
-    .boton-agregar {
-      background-color: #28a745; // Green
-      color: white;
-      padding: 12px 18px;
-      border: none;
-      border-radius: 5px;
-      cursor: pointer;
-      font-size: 1.05em;
-      transition: background-color 0.3s ease;
-      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-
-      i { // Assuming Font Awesome or similar for icons
-        margin-right: 8px;
-      }
-
-      &:hover {
-        background-color: #218838;
-        box-shadow: 0 4px 8px rgba(0,0,0,0.15);
-      }
-      &:active {
-        background-color: #1e7e34;
-      }
-    }
   }
 
   .grid-cuentos {
@@ -55,33 +31,33 @@
 }
 
 // Responsive adjustments if necessary
-@media (max-width: 768px) {
-  .cuentos-admin-container h2 {
-    font-size: 1.8em;
-  }
-  .admin-acciones-globales {
-    text-align: center;
-    .boton-agregar {
-      width: 100%;
-      margin-bottom: 15px;
+  @media (max-width: 768px) {
+    .cuentos-admin-container h2 {
+      font-size: 1.8em;
     }
-  }
+    .admin-acciones-globales {
+      text-align: center;
+      .btn {
+        width: 100%;
+        margin-bottom: 15px;
+      }
+    }
   .grid-cuentos {
     grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
     gap: 20px;
   }
 }
 
-@media (max-width: 480px) {
-  .cuentos-admin-container h2 {
-    font-size: 1.5em;
+  @media (max-width: 480px) {
+    .cuentos-admin-container h2 {
+      font-size: 1.5em;
+    }
+     .grid-cuentos {
+      grid-template-columns: 1fr; // Single column on very small screens
+      gap: 15px;
+    }
+    .admin-acciones-globales .btn {
+      font-size: 1em;
+      padding: 10px 15px;
+    }
   }
-   .grid-cuentos {
-    grid-template-columns: 1fr; // Single column on very small screens
-    gap: 15px;
-  }
-  .admin-acciones-globales .boton-agregar {
-    font-size: 1em;
-    padding: 10px 15px;
-  }
-}


### PR DESCRIPTION
## Summary
- use Bootstrap classes for the add book button
- clean up the custom `.boton-agregar` styles

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1929b4dc83278448a729eee342ec