### PR TITLE
Implement admin user management page

### DIFF
--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
@@ -2,6 +2,7 @@ import { Component, HostListener, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PedidoService } from '../../../../services/pedido.service';
 import { Pedido } from '../../../../model/pedido.model';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-admin-pedidos',
@@ -18,8 +19,9 @@ export class AdminPedidosComponent implements OnInit {
 
   isMobile = false;
   showReasonDialog = false;
+  private userIdFilter: string | null = null;
 
-  constructor(private pedidoService: PedidoService) {}
+  constructor(private pedidoService: PedidoService, private route: ActivatedRoute) {}
 
   @HostListener('window:resize')
   onResize() {
@@ -28,12 +30,19 @@ export class AdminPedidosComponent implements OnInit {
 
   ngOnInit(): void {
     this.onResize();
+    this.route.queryParamMap.subscribe(params => {
+      this.userIdFilter = params.get('userId');
+      this.cargarPedidos();
+    });
+  }
+
+  private cargarPedidos(): void {
     this.pedidoService.getOrders().subscribe({
       next: data => {
-         this.pedidos = data
-        //   .sort((a, b) => new Date(b.fecha).getTime() - new Date(a.fecha).getTime())
-        //   .slice(0, 5);
-       this.isLoading = false;
+        this.pedidos = this.userIdFilter
+          ? data.filter(p => String(p.userId) === this.userIdFilter)
+          : data;
+        this.isLoading = false;
       },
       error: err => {
         console.error('Error fetching orders:', err);

--- a/src/app/components/pages/admin/admin-usuarios/admin-usuarios.component.html
+++ b/src/app/components/pages/admin/admin-usuarios/admin-usuarios.component.html
@@ -1,1 +1,59 @@
-<p>admin-usuarios works!</p>
+<div class="admin-usuarios-container">
+  <h2>Usuarios</h2>
+
+  <div *ngIf="isLoading">Cargando usuarios...</div>
+  <div *ngIf="errorMensaje">{{ errorMensaje }}</div>
+
+  <table *ngIf="!isLoading && !errorMensaje && !isMobile">
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Nombre</th>
+        <th>Email</th>
+        <th>Teléfono</th>
+        <th>Rol</th>
+        <th>Estado</th>
+        <th>Acciones</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let u of usuarios; trackBy: trackById">
+        <td>{{ u.id }}</td>
+        <td>{{ u.nombre }} {{ u.apellido }}</td>
+        <td>{{ u.email }}</td>
+        <td>{{ u.telefono }}</td>
+        <td>{{ u.role }}</td>
+        <td>{{ u.habilitado ? 'Habilitado' : 'Deshabilitado' }}</td>
+        <td class="acciones">
+          <button class="btn btn-success" (click)="toggleHabilitar(u)">
+            {{ u.habilitado ? 'Deshabilitar' : 'Habilitar' }}
+          </button>
+          <button class="btn btn-secondary" (click)="enviarCorreo(u)">Correo</button>
+          <button class="btn btn-secondary" *ngIf="u.role !== 'ADMIN'" (click)="hacerAdmin(u)">Hacer admin</button>
+          <button class="btn btn-primary" (click)="verPedidos(u)">Pedidos</button>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <ng-container *ngIf="!isLoading && !errorMensaje && isMobile">
+    <div class="usuario-cards">
+      <div class="usuario-card" *ngFor="let u of usuarios; trackBy: trackById">
+        <div><strong>ID:</strong> {{ u.id }}</div>
+        <div><strong>Nombre:</strong> {{ u.nombre }} {{ u.apellido }}</div>
+        <div><strong>Email:</strong> {{ u.email }}</div>
+        <div><strong>Teléfono:</strong> {{ u.telefono }}</div>
+        <div><strong>Rol:</strong> {{ u.role }}</div>
+        <div><strong>Estado:</strong> {{ u.habilitado ? 'Habilitado' : 'Deshabilitado' }}</div>
+        <div class="acciones">
+          <button class="btn btn-success" (click)="toggleHabilitar(u)">
+            {{ u.habilitado ? 'Deshabilitar' : 'Habilitar' }}
+          </button>
+          <button class="btn btn-secondary" (click)="enviarCorreo(u)">Correo</button>
+          <button class="btn btn-secondary" *ngIf="u.role !== 'ADMIN'" (click)="hacerAdmin(u)">Hacer admin</button>
+          <button class="btn btn-primary" (click)="verPedidos(u)">Pedidos</button>
+        </div>
+      </div>
+    </div>
+  </ng-container>
+</div>

--- a/src/app/components/pages/admin/admin-usuarios/admin-usuarios.component.scss
+++ b/src/app/components/pages/admin/admin-usuarios/admin-usuarios.component.scss
@@ -1,0 +1,73 @@
+.admin-usuarios-container {
+  padding: 1rem;
+  max-width: 1200px;
+  margin: auto;
+
+  h2 {
+    margin-bottom: 1rem;
+    text-align: center;
+    color: #3f2a14;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+    background: #fff;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+    th,
+    td {
+      padding: 0.75rem;
+      border-bottom: 1px solid #ddd;
+    }
+
+    th {
+      background: #f8f4f0;
+      color: #3f2a14;
+      text-align: left;
+    }
+
+    tbody tr:nth-child(even) {
+      background: #fff7ed;
+    }
+
+    tbody tr:hover {
+      background: #fff2d9;
+    }
+  }
+
+  .acciones {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+}
+
+@media (max-width: 600px) {
+  table {
+    display: none;
+  }
+
+  .usuario-cards {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .usuario-card {
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    background: #fff;
+    padding: 1rem;
+
+    .acciones {
+      margin-top: 0.5rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.25rem;
+    }
+  }
+}

--- a/src/app/components/pages/admin/admin-usuarios/admin-usuarios.component.spec.ts
+++ b/src/app/components/pages/admin/admin-usuarios/admin-usuarios.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { AdminUsuariosComponent } from './admin-usuarios.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('AdminUsuariosComponent', () => {
   let component: AdminUsuariosComponent;
@@ -8,7 +9,8 @@ describe('AdminUsuariosComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [AdminUsuariosComponent]
+      imports: [RouterTestingModule, HttpClientTestingModule],
+      declarations: [AdminUsuariosComponent]
     })
     .compileComponents();
 

--- a/src/app/components/pages/admin/admin-usuarios/admin-usuarios.component.ts
+++ b/src/app/components/pages/admin/admin-usuarios/admin-usuarios.component.ts
@@ -1,4 +1,7 @@
-import { Component } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
+import { Router } from '@angular/router';
+import { UserService } from '../../../../services/user.service';
+import { User } from '../../../../model/user.model';
 
 @Component({
   selector: 'app-admin-usuarios',
@@ -7,6 +10,66 @@ import { Component } from '@angular/core';
   templateUrl: './admin-usuarios.component.html',
   styleUrls: ['./admin-usuarios.component.scss']
 })
-export class AdminUsuariosComponent {
+export class AdminUsuariosComponent implements OnInit {
+  usuarios: User[] = [];
+  isLoading = true;
+  errorMensaje: string | null = null;
+  isMobile = false;
 
+  constructor(private userService: UserService, private router: Router) {}
+
+  @HostListener('window:resize')
+  onResize() {
+    this.isMobile = window.innerWidth <= 600;
+  }
+
+  ngOnInit(): void {
+    this.onResize();
+    this.userService.obtenerUsuarios().subscribe({
+      next: data => {
+        this.usuarios = data;
+        this.isLoading = false;
+      },
+      error: err => {
+        console.error('Error fetching users:', err);
+        this.errorMensaje = 'No se pudieron cargar los usuarios';
+        this.isLoading = false;
+      }
+    });
+  }
+
+  toggleHabilitar(user: User): void {
+    const nuevoEstado = !user.habilitado;
+    const id = user.id || 0;
+    this.userService.cambiarEstado(id, nuevoEstado).subscribe({
+      next: updated => {
+        user.habilitado = updated.habilitado;
+      },
+      error: err => console.error('Error updating user state', err)
+    });
+  }
+
+  enviarCorreo(user: User): void {
+    if (typeof window !== 'undefined') {
+      window.location.href = `mailto:${user.email}`;
+    }
+  }
+
+  hacerAdmin(user: User): void {
+    const id = user.id || 0;
+    this.userService.convertirEnAdmin(id).subscribe({
+      next: updated => {
+        user.role = updated.role;
+      },
+      error: err => console.error('Error converting user to admin', err)
+    });
+  }
+
+  verPedidos(user: User): void {
+    this.router.navigate(['/admin/pedidos'], { queryParams: { userId: user.id } });
+  }
+
+  trackById(_: number, u: User): number | undefined {
+    return u.id;
+  }
 }

--- a/src/app/model/user.model.ts
+++ b/src/app/model/user.model.ts
@@ -6,5 +6,6 @@ export interface User {
     telefono: string;
     documento?: string;
     role?: 'USER' | 'ADMIN';
-  }
+    habilitado?: boolean;
+}
   

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -13,4 +13,12 @@ export class UserService {
   obtenerUsuarios(): Observable<User[]> {
     return this.http.get<User[]>(`${this.apiUrl}/usuarios`);
   }
+
+  cambiarEstado(id: number, habilitado: boolean): Observable<User> {
+    return this.http.put<User>(`${this.apiUrl}/${id}/estado`, { habilitado }, { withCredentials: true });
+  }
+
+  convertirEnAdmin(id: number): Observable<User> {
+    return this.http.post<User>(`${this.apiUrl}/${id}/make-admin`, {}, { withCredentials: true });
+  }
 }


### PR DESCRIPTION
## Summary
- extend User model with `habilitado` flag
- add state and role update calls to `UserService`
- build admin user maintenance page with actions for enabling, emailing, promoting, and viewing orders
- filter orders by user ID in admin orders page
- update tests

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1906f2c48327963fc31f5d1def53