### PR TITLE
Remove Angular Material dependencies

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -32,7 +32,6 @@
               }
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles.scss"
             ],
             "scripts": [],
@@ -105,7 +104,6 @@
               }
             ],
             "styles": [
-              "@angular/material/prebuilt-themes/azure-blue.css",
               "src/styles.scss"
             ],
             "scripts": []

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@angular/compiler": "^18.0.0",
         "@angular/core": "^18.0.0",
         "@angular/forms": "^18.0.0",
-        "@angular/material": "^18.0.0",
         "@angular/platform-browser": "^18.0.0",
         "@angular/platform-browser-dynamic": "^18.0.0",
         "@angular/platform-server": "^18.0.0",
@@ -697,24 +696,6 @@
         "@angular/common": "18.2.13",
         "@angular/core": "18.2.13",
         "@angular/platform-browser": "18.2.13",
-        "rxjs": "^6.5.3 || ^7.4.0"
-      }
-    },
-    "node_modules/@angular/material": {
-      "version": "18.2.14",
-      "resolved": "https://registry.npmjs.org/@angular/material/-/material-18.2.14.tgz",
-      "integrity": "sha512-28pxzJP49Mymt664WnCtPkKeg7kXUsQKTKGf/Kl95rNTEdTJLbnlcc8wV0rT0yQNR7kXgpfBnG7h0ETLv/iu5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/animations": "^18.0.0 || ^19.0.0",
-        "@angular/cdk": "18.2.14",
-        "@angular/common": "^18.0.0 || ^19.0.0",
-        "@angular/core": "^18.0.0 || ^19.0.0",
-        "@angular/forms": "^18.0.0 || ^19.0.0",
-        "@angular/platform-browser": "^18.0.0 || ^19.0.0",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@angular/compiler": "^18.0.0",
     "@angular/core": "^18.0.0",
     "@angular/forms": "^18.0.0",
-    "@angular/material": "^18.0.0",
     "@angular/platform-browser": "^18.0.0",
     "@angular/platform-browser-dynamic": "^18.0.0",
     "@angular/platform-server": "^18.0.0",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -5,7 +5,6 @@ import { routes } from './app.routes';
 import { provideClientHydration } from '@angular/platform-browser';
 import { provideHttpClient,withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { authInterceptor } from './services/auth.interceptor';
 import { ThemeService } from './services/theme.service';
 import * as Sentry from '@sentry/angular';
@@ -19,7 +18,6 @@ export const appConfig: ApplicationConfig = {
     provideClientHydration(),
     provideHttpClient(withInterceptors([authInterceptor])),
     provideAnimationsAsync(),
-    importProvidersFrom(MatSnackBarModule),
     {
       provide: APP_INITIALIZER,
       useFactory: (ts: ThemeService) => () => ts.loadTheme(),

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -43,3 +43,10 @@
   </ul>
   <div id="cart-announce" class="visually-hidden" aria-live="polite"></div>
 </nav>
+<app-modal
+  *ngIf="showLoginModal"
+  title="Iniciar sesión"
+  (close)="closeLoginDialog()"
+>
+  <app-login (close)="closeLoginDialog()"></app-login>
+</app-modal>

--- a/src/app/components/navbar/navbar.component.ts
+++ b/src/app/components/navbar/navbar.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { LoginComponent } from '../pages/login/login.component';
-import { MatDialog } from '@angular/material/dialog';
 import { CartService } from '../../services/carrito.service';
 import { Router, RouterModule } from '@angular/router';
 import { DrawerService } from '../../services/drawer.service';
@@ -13,6 +12,7 @@ import { Cuento } from '../../model/cuento.model';
 import { User } from '../../model/user.model';
 import { FormsModule } from '@angular/forms';
 import { LazyLoadImageDirective } from '../../directives/lazy-load-image.directive';
+import { ModalComponent } from '../app-modal/modal.component';
 
 
 
@@ -27,7 +27,8 @@ import { LazyLoadImageDirective } from '../../directives/lazy-load-image.directi
     RouterModule, // habilita routerLink en la plantilla
     FormsModule,
     LazyLoadImageDirective,
-    // otros imports que tengas como MatDialogModule, etc.
+    ModalComponent,
+    LoginComponent
   ]
 })
 export class NavbarComponent implements OnInit {
@@ -35,8 +36,9 @@ export class NavbarComponent implements OnInit {
   user: User | null = null;
   mostrarPerfil = false;
   searchQuery = '';
+  showLoginModal = false;
+
   constructor(
-    private dialog: MatDialog,
     public CartService: CartService,
     public authService: AuthService,
     private router: Router,
@@ -52,12 +54,12 @@ export class NavbarComponent implements OnInit {
 
 
 
-  openLoginDialog() {
-    this.dialog.open(LoginComponent, {
-     // maxWidth: '50vw',
-     // width: '80%',
-      panelClass: 'login-modal'
-    });
+  openLoginDialog(): void {
+    this.showLoginModal = true;
+  }
+
+  closeLoginDialog(): void {
+    this.showLoginModal = false;
   }
   ngOnInit(): void {
     this.CartService.items$.subscribe(items => {

--- a/src/app/components/pages/Home/home.module.ts
+++ b/src/app/components/pages/Home/home.module.ts
@@ -5,7 +5,6 @@ import { HeroBannerComponent } from '../../hero-banner/hero-banner.component';
 import { CuentosGridComponent } from '../../cuentos-grid/cuentos-grid.component';
 import { HomeComponent } from './home.component';
 import { CuentosModule } from '../cuentos/cuentos.module';
-import { MatCardModule } from '@angular/material/card';
 import { SharedModule } from './../../shared.module';
 
 
@@ -14,7 +13,6 @@ import { SharedModule } from './../../shared.module';
   imports: [
     CommonModule,
     HomeRoutingModule,
-    MatCardModule,
     SharedModule,
     CuentosModule
   ],

--- a/src/app/components/pages/login/login.component.ts
+++ b/src/app/components/pages/login/login.component.ts
@@ -1,10 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { Component, OnInit, Optional } from '@angular/core';
+import { Component, OnInit, Output, EventEmitter } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService} from '../../../services/auth.service';
-import { MatDialogRef } from '@angular/material/dialog';
 import { LazyLoadImageDirective } from '../../../directives/lazy-load-image.directive';
 
 @Component({
@@ -15,6 +14,7 @@ import { LazyLoadImageDirective } from '../../../directives/lazy-load-image.dire
   styleUrls: ['./login.component.scss']
 })
 export class LoginComponent implements OnInit {
+  @Output() close = new EventEmitter<void>();
   loginForm!: FormGroup;
   error: string = '';
   returnTo: string = '/';
@@ -23,8 +23,7 @@ export class LoginComponent implements OnInit {
     private fb: FormBuilder,
     private router: Router,
     private route: ActivatedRoute,
-    private authService:AuthService,
-    @Optional() private dialogRef?: MatDialogRef<LoginComponent> // 👈 usando @Optional()
+    private authService:AuthService
 
   ) {}
 
@@ -57,8 +56,8 @@ export class LoginComponent implements OnInit {
         this.router.navigate(['/home']);
       }
 
-      // CIERRA el modal
-      this.dialogRef?.close(); // 👈 Solo si existe
+      // Notifica al contenedor para cerrar el modal si aplica
+      this.close.emit();
       },
       error: (err) => {
         this.error=err;

--- a/src/app/services/toast.service.ts
+++ b/src/app/services/toast.service.ts
@@ -1,11 +1,26 @@
-import { Injectable } from '@angular/core';
-import { MatSnackBar } from '@angular/material/snack-bar';
+import { Injectable, Inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 
 @Injectable({ providedIn: 'root' })
 export class ToastService {
-  constructor(private snackBar: MatSnackBar) {}
+  private container: HTMLElement | null = null;
 
-  show(message: string) {
-    this.snackBar.open(message, 'Cerrar', { duration: 2000 });
+  constructor(@Inject(DOCUMENT) private document: Document) {
+    this.container = this.document.getElementById('toast-container');
+  }
+
+  show(
+    message: string,
+    type: 'success' | 'warning' | 'error' | 'info' = 'info'
+  ): void {
+    if (!this.container) {
+      this.container = this.document.body;
+    }
+
+    const toast = this.document.createElement('div');
+    toast.className = `alert alert--${type}`;
+    toast.textContent = message;
+    this.container.appendChild(toast);
+    setTimeout(() => toast.remove(), 2000);
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -17,5 +17,6 @@
 </head>
 <body>
   <app-root></app-root>
+  <div id="toast-container" aria-live="polite"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- drop all Angular Material imports and theme
- rework ToastService to append custom alerts
- use `app-modal` for login dialog
- swap out `MatCardModule` in HomeModule

## Testing
- `npm install` *(fails: ng not found because no internet)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b3fb73e9883279e435e15ae868d38