### PR TITLE
Fix Vercel build by configuring prerender routes

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -37,7 +37,9 @@
             "scripts": [],
             "allowedCommonJsDependencies": ["localforage"],
             "server": "src/main.server.ts",
-            "prerender": true,
+            "prerender": {
+              "routes": ["/"]
+            },
             "ssr": {
               "entry": "server.ts"
             }


### PR DESCRIPTION
## Summary
- add explicit routes to the Angular `prerender` option

## Testing
- `npm run vercel-build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc2f1353c83278bfadb27a3c254c5