### PR TITLE
Disable Angular prerendering to fix build

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -37,7 +37,7 @@
             "scripts": [],
             "allowedCommonJsDependencies": ["localforage"],
             "server": "src/main.server.ts",
-            "prerender": true,
+            "prerender": false,
             "ssr": {
               "entry": "server.ts"
             }


### PR DESCRIPTION
## Summary
- disable the Angular `prerender` option since the build schema expects a boolean

## Testing
- `npm run vercel-build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bc2f1353c83278bfadb27a3c254c5