### PR TITLE
Implement voucher URL modal display

### DIFF
--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
@@ -73,7 +73,13 @@
   </ng-container>
 </div>
 <app-modal *ngIf="selectedPedido" [title]="'Voucher Pedido #' + (selectedPedido!.Id || selectedPedido!.id)" (close)="cerrarModal()">
-  <img *ngIf="voucherImg" [src]="voucherImg" alt="Voucher" />
+  <ng-container *ngIf="voucherUrl">
+    <img *ngIf="!voucherUrl.endsWith('.pdf')" [src]="voucherUrl" alt="Voucher" />
+    <iframe *ngIf="voucherUrl.endsWith('.pdf')" [src]="voucherUrl" width="100%" height="500px"></iframe>
+    <div class="descargar">
+      <button class="btn btn-primary" (click)="descargarVoucher()">Descargar</button>
+    </div>
+  </ng-container>
   <div modal-footer>
     <button class="btn btn-success" (click)="validarPago()" [disabled]="processing">Validar Pago</button>
     <button class="btn btn-danger" (click)="rechazarPago()" [disabled]="processing">Rechazar Pago</button>

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.spec.ts
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.spec.ts
@@ -11,7 +11,7 @@ describe('AdminPedidosComponent', () => {
   let pedidoServiceSpy: jasmine.SpyObj<PedidoService>;
 
   beforeEach(async () => {
-    pedidoServiceSpy = jasmine.createSpyObj('PedidoService', ['rejectVoucher']);
+    pedidoServiceSpy = jasmine.createSpyObj('PedidoService', ['updateOrderStatus']);
 
     await TestBed.configureTestingModule({
       imports: [AdminPedidosComponent, InputDialogComponent, ModalComponent],
@@ -32,7 +32,7 @@ describe('AdminPedidosComponent', () => {
     component.rechazarPago();
     expect(component.showReasonDialog).toBeTrue();
     component.confirmarRechazo('no valido');
-    expect(pedidoServiceSpy.rejectVoucher).toHaveBeenCalledWith(1, 'no valido');
+    expect(pedidoServiceSpy.updateOrderStatus).toHaveBeenCalledWith(1, 'PAGO_RECHAZADO', 'no valido');
   });
 
   it('should not call service when canceling', () => {
@@ -40,7 +40,7 @@ describe('AdminPedidosComponent', () => {
     component.rechazarPago();
     component.cancelarRechazo();
     expect(component.showReasonDialog).toBeFalse();
-    expect(pedidoServiceSpy.rejectVoucher).not.toHaveBeenCalled();
+    expect(pedidoServiceSpy.updateOrderStatus).not.toHaveBeenCalled();
   });
 
   describe('trackByPedidoId', () => {

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.ts
@@ -14,7 +14,7 @@ export class AdminPedidosComponent implements OnInit {
   isLoading = true;
   errorMensaje: string | null = null;
   selectedPedido: Pedido | null = null;
-  voucherImg: string | null = null;
+  voucherUrl: string | null = null;
   processing = false;
 
   isMobile = false;
@@ -55,28 +55,31 @@ export class AdminPedidosComponent implements OnInit {
   abrirModal(pedido: Pedido): void {
     this.selectedPedido = pedido;
     const id = pedido.Id || pedido.id || 0;
-    this.pedidoService.getVoucher(id).subscribe({
-      next: blob => {
-        this.voucherImg = URL.createObjectURL(blob);
+    this.pedidoService.getVoucherUrl(id).subscribe({
+      next: url => {
+        this.voucherUrl = url;
       },
-      error: err => console.error('Error fetching voucher', err)
+      error: err => console.error('Error fetching voucher url', err)
     });
   }
 
   cerrarModal(): void {
-    if (this.voucherImg) {
-      URL.revokeObjectURL(this.voucherImg);
-    }
     this.selectedPedido = null;
-    this.voucherImg = null;
+    this.voucherUrl = null;
     this.processing = false;
+  }
+
+  descargarVoucher(): void {
+    if (this.voucherUrl) {
+      window.open(this.voucherUrl, '_blank');
+    }
   }
 
   validarPago(): void {
     if (!this.selectedPedido) return;
     this.processing = true;
     const id = this.selectedPedido.Id || this.selectedPedido.id || 0;
-    this.pedidoService.validateVoucher(id).subscribe({
+    this.pedidoService.updateOrderStatus(id, 'PAGO_VERIFICADO').subscribe({
       next: () => {
         this.selectedPedido!.estado = 'PAGO_VERIFICADO';
         this.cerrarModal();
@@ -98,7 +101,7 @@ export class AdminPedidosComponent implements OnInit {
     this.showReasonDialog = false;
     this.processing = true;
     const id = this.selectedPedido.Id || this.selectedPedido.id || 0;
-    this.pedidoService.rejectVoucher(id, motivo).subscribe({
+    this.pedidoService.updateOrderStatus(id, 'PAGO_RECHAZADO', motivo).subscribe({
       next: () => {
         this.selectedPedido!.estado = 'PAGO_RECHAZADO';
         this.cerrarModal();

--- a/src/app/services/pedido.service.ts
+++ b/src/app/services/pedido.service.ts
@@ -40,18 +40,23 @@ export class PedidoService {
     return this.http.get(`${this.apiUrl}/${id}/pdf`, { responseType: 'blob' });
   }
 
-  getVoucher(id: number): Observable<Blob> {
-    return this.http.get(`${this.apiUrl}/${id}/voucher`, {
-      responseType: 'blob',
+  /** Obtiene la URL del voucher asociado al pedido */
+  getVoucherUrl(id: number): Observable<string> {
+    return this.http.get(`${this.apiUrl}/${id}/voucher-url`, {
+      responseType: 'text',
       withCredentials: true
     });
   }
 
-  validateVoucher(id: number): Observable<any> {
-    return this.http.post(`${this.apiUrl}/${id}/validate-voucher`, {}, { withCredentials: true });
-  }
-
-  rejectVoucher(id: number, motivo: string): Observable<any> {
-    return this.http.post(`${this.apiUrl}/${id}/reject-voucher`, { motivo }, { withCredentials: true });
+  /**
+   * Actualiza el estado del pedido. Opcionalmente se puede enviar un motivo
+   * en caso de que el estado sea de rechazo.
+   */
+  updateOrderStatus(id: number, estado: string, motivo?: string): Observable<any> {
+    return this.http.patch(
+      `${this.apiUrl}/${id}/status`,
+      { estado, motivo },
+      { withCredentials: true }
+    );
   }
 }


### PR DESCRIPTION
## Summary
- fetch voucher URL in Admin pedidos page
- show voucher as image or PDF in modal and allow downloading
- patch order status for payment verification and rejection
- update Admin pedidos tests
- add service helpers for voucher URL and status updates

## Testing
- `npm test -- --browsers ChromeHeadless --watch=false` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b40b81d348327906d00ee48958aa3