### PR TITLE
Add voucher replacement flow

### DIFF
--- a/src/app/components/pages/order-detail/order-detail.component.html
+++ b/src/app/components/pages/order-detail/order-detail.component.html
@@ -52,12 +52,36 @@
       </ng-template>
     </section>
 
-    <section class="acciones-pedido" *ngIf="!isLoading">
-      <button *ngIf="isPagoPendiente()" (click)="pagarAhora()" class="btn btn-success btn-pagar">
-        <i class="fas fa-credit-card"></i> Pagar ahora
-      </button>
-      <!-- Otros botones de acción podrían ir aquí, ej. "Cancelar Pedido" si el estado lo permite -->
-    </section>
+      <section class="acciones-pedido" *ngIf="!isLoading">
+        <button *ngIf="isPagoPendiente()" (click)="pagarAhora()" class="btn btn-success btn-pagar">
+          <i class="fas fa-credit-card"></i> Pagar ahora
+        </button>
+        <button *ngIf="pedido?.estado === 'PAGO_ENVIADO'" (click)="confirmReplaceVoucher()" class="btn btn-primary">
+          Reemplazar voucher
+        </button>
+        <!-- Otros botones de acción podrían ir aquí, ej. "Cancelar Pedido" si el estado lo permite -->
+      </section>
 
   </div>
 </div>
+<app-modal
+  *ngIf="showVoucherModal"
+  title="Reemplazar voucher"
+  (close)="showVoucherModal = false"
+>
+  <div class="replace-voucher-modal">
+    <input
+      type="file"
+      accept="application/pdf,image/jpeg,image/png"
+      (change)="onVoucherSelected($event)"
+    />
+    <p>{{ voucherNombre || 'Sin archivo seleccionado' }}</p>
+    <button
+      class="btn btn-primary"
+      (click)="enviarNuevoVoucher()"
+      [disabled]="!voucherFile || uploading"
+    >
+      Enviar
+    </button>
+  </div>
+</app-modal>


### PR DESCRIPTION
## Summary
- allow replacing a voucher from Order detail
- show modal for voucher upload when replacing

## Testing
- `npx ng test --watch=false --browsers=ChromeHeadless` *(fails: ng not found / network)*

------
https://chatgpt.com/codex/tasks/task_e_686bcb47c6f88327ac336fa4a4a090d0