### PR TITLE
Add order statistics charts

### DIFF
--- a/src/app/components/order-stats/order-stats.component.html
+++ b/src/app/components/order-stats/order-stats.component.html
@@ -1,0 +1,4 @@
+<div class="order-stats">
+  <canvas baseChart [data]="pieData" chartType="pie"></canvas>
+  <canvas baseChart [data]="barData" [options]="barOptions" chartType="bar"></canvas>
+</div>

--- a/src/app/components/order-stats/order-stats.component.scss
+++ b/src/app/components/order-stats/order-stats.component.scss
@@ -1,0 +1,5 @@
+.order-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}

--- a/src/app/components/order-stats/order-stats.component.ts
+++ b/src/app/components/order-stats/order-stats.component.ts
@@ -1,0 +1,44 @@
+import { Component, OnInit } from '@angular/core';
+import { ChartData, ChartOptions } from 'chart.js';
+import { OrderStatsService } from '../../services/order-stats.service';
+
+@Component({
+  selector: 'app-order-stats',
+  templateUrl: './order-stats.component.html',
+  styleUrls: ['./order-stats.component.scss']
+})
+export class OrderStatsComponent implements OnInit {
+  pieData: ChartData<'pie'> = {
+    labels: ['Pago pendiente', 'Pago enviado'],
+    datasets: [{ data: [0, 0] }]
+  };
+
+  barData: ChartData<'bar'> = {
+    labels: [],
+    datasets: [{ data: [], backgroundColor: '#FFAD60' }]
+  };
+
+  barOptions: ChartOptions<'bar'> = {
+    responsive: true
+  };
+
+  constructor(private statsService: OrderStatsService) {}
+
+  ngOnInit(): void {
+    this.loadData();
+  }
+
+  private loadData() {
+    this.statsService.getStatusCounts().subscribe(counts => {
+      this.pieData.datasets[0].data = [
+        counts['PAGO_PENDIENTE'] || 0,
+        counts['PAGO_ENVIADO'] || 0
+      ];
+    });
+
+    this.statsService.getOrdersByDay(7).subscribe(entries => {
+      this.barData.labels = entries.map(e => e.date.slice(5));
+      this.barData.datasets[0].data = entries.map(e => e.count);
+    });
+  }
+}

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
@@ -29,6 +29,10 @@
     </ng-container>
   </section>
 
+  <section class="orders-stats" *ngIf="!isLoading && !errorMensaje">
+    <app-order-stats></app-order-stats>
+  </section>
+
   <section class="users-section" *ngIf="!isLoading && !errorMensaje">
     <h3>Usuarios registrados</h3>
     <div class="users-grid">

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.module.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.module.ts
@@ -5,13 +5,14 @@ import { RouterModule, Routes } from '@angular/router';
 import { NgChartsModule } from 'ng2-charts';
 import { AdminDashboardComponent } from './admin-dashboard.component';
 import { StatCardComponent } from '../../../stat-card/stat-card.component';
+import { OrderStatsComponent } from '../../../order-stats/order-stats.component';
 
 const routes: Routes = [
   { path: '', component: AdminDashboardComponent }
 ];
 
 @NgModule({
-  declarations: [AdminDashboardComponent],
+  declarations: [AdminDashboardComponent, OrderStatsComponent],
   imports: [CommonModule, FormsModule, NgChartsModule, RouterModule.forChild(routes), StatCardComponent],
   exports: [AdminDashboardComponent]
 })

--- a/src/app/services/order-stats.service.spec.ts
+++ b/src/app/services/order-stats.service.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { OrderStatsService } from './order-stats.service';
+import { PedidoService } from './pedido.service';
+import { Pedido } from '../model/pedido.model';
+
+class MockPedidoService {
+  constructor(private orders: Pedido[]) {}
+  getOrders() { return of(this.orders); }
+}
+
+describe('OrderStatsService', () => {
+  const today = new Date();
+  const format = (d: Date) => d.toISOString().slice(0,10);
+  const orders: Pedido[] = [
+    { Id:1, id:1, fecha: format(today), nombre:'', correo:'', direccion:'', telefono:'', items:[], total:10, estado:'PAGO_PENDIENTE', userId:1, correoUsuario:'' },
+    { Id:2, id:2, fecha: format(today), nombre:'', correo:'', direccion:'', telefono:'', items:[], total:20, estado:'PAGO_ENVIADO', userId:1, correoUsuario:'' },
+    { Id:3, id:3, fecha: format(new Date(today.getTime()-86400000)), nombre:'', correo:'', direccion:'', telefono:'', items:[], total:15, estado:'PAGO_PENDIENTE', userId:1, correoUsuario:'' }
+  ];
+
+  let service: OrderStatsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        OrderStatsService,
+        { provide: PedidoService, useValue: new MockPedidoService(orders) }
+      ]
+    });
+    service = TestBed.inject(OrderStatsService);
+  });
+
+  it('should group orders by status', (done) => {
+    service.getStatusCounts().subscribe(counts => {
+      expect(counts['PAGO_PENDIENTE']).toBe(2);
+      expect(counts['PAGO_ENVIADO']).toBe(1);
+      done();
+    });
+  });
+
+  it('should count orders per day', (done) => {
+    service.getOrdersByDay(2).subscribe(data => {
+      expect(data.length).toBe(2);
+      // first day is yesterday
+      expect(data[0].count).toBe(1);
+      expect(data[1].count).toBe(2);
+      done();
+    });
+  });
+});

--- a/src/app/services/order-stats.service.ts
+++ b/src/app/services/order-stats.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import { map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
+import { PedidoService } from './pedido.service';
+import { Pedido } from '../model/pedido.model';
+
+interface OrdersPerDay {
+  date: string;
+  count: number;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class OrderStatsService {
+  constructor(private pedidoService: PedidoService) {}
+
+  /** Counts orders grouped by their "estado" field */
+  getStatusCounts(): Observable<Record<string, number>> {
+    return this.pedidoService.getOrders().pipe(
+      map(orders => orders.reduce((acc: Record<string, number>, o: Pedido) => {
+        const estado = o.estado;
+        acc[estado] = (acc[estado] || 0) + 1;
+        return acc;
+      }, {}))
+    );
+  }
+
+  /** Returns the number of orders for each of the last `days` days */
+  getOrdersByDay(days: number): Observable<OrdersPerDay[]> {
+    return this.pedidoService.getOrders().pipe(
+      map(orders => {
+        const today = new Date();
+        const results: OrdersPerDay[] = [];
+        for (let i = days - 1; i >= 0; i--) {
+          const date = new Date(today);
+          date.setDate(today.getDate() - i);
+          const dateStr = date.toISOString().slice(0, 10);
+          const count = orders.filter(o => (o.fecha ?? '').slice(0, 10) === dateStr).length;
+          results.push({ date: dateStr, count });
+        }
+        return results;
+      })
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `OrderStatsService` for order grouping logic
- create `OrderStatsComponent` showing pie and bar charts
- declare the new component in `AdminDashboardModule`
- embed charts within admin dashboard
- provide unit tests for `OrderStatsService`
- fix module import path for `OrderStatsComponent`

## Testing
- `npm test --silent -- --no-watch --browsers=ChromeHeadless` *(fails: ng not found)*


------
https://chatgpt.com/codex/tasks/task_e_686c5151e18083279d2ead39cff9aca8