### PR TITLE
Add breadcrumb to cuento detail

### DIFF
--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -1,4 +1,9 @@
 <div class="detalle-pagina">
+  <nav class="breadcrumb">
+    <a routerLink="/home">Inicio</a> /
+    <a routerLink="/cuentos">Cuentos</a> /
+    <span>{{ cuento?.titulo }}</span>
+  </nav>
   <div class="detalle-grid">
     <div class="hero">
       <div class="badges">

--- a/src/app/components/detalle-cuento/detalle-cuento.component.scss
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.scss
@@ -7,6 +7,20 @@
   justify-content: center;
 }
 
+.breadcrumb {
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+
+  a {
+    color: #A66E38;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
 .detalle-grid {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- add breadcrumb navigation links to detalle-cuento
- style breadcrumb in detalle-cuento styles

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cfa32287883279a82baf7fe62957a