### PR TITLE
Add gallery to book details

### DIFF
--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -1,20 +1,29 @@
 <div class="detalle-pagina">
   <div class="detalle-grid">
     <div class="hero">
-      <div class="badges">
-        <span class="badge category" *ngIf="cuento?.categoria">{{ cuento?.categoria }}</span>
-        <span class="badge nuevo" *ngIf="badgeLabel==='Nuevo'">Nuevo</span>
-        <span class="badge top" *ngIf="badgeLabel && badgeLabel!=='Nuevo'">{{ badgeLabel }}</span>
-        <span class="badge oferta" *ngIf="hasDiscount">-{{ cuento?.descuento }}% OFF</span>
-      </div>
-      <div class="imagen-skeleton" *ngIf="cargandoImagen"></div>
-      <img
-        [appLazyLoad]="cuento?.imagenUrl || 'assets/placeholder-cuento.jpg'"
-        alt="Imagen del cuento"
-        (error)="cargarImagenPlaceholder($event)"
-        (load)="imagenCargada()"
-        [class.loaded]="!cargandoImagen"
-      />
+      <figure class="galeria">
+        <div class="thumbnails" *ngIf="cuento?.galeria?.length">
+          <button type="button" *ngFor="let img of cuento?.galeria; let i = index" (click)="selectImage(i)" [class.active]="i===selectedImageIndex">
+            <img [appLazyLoad]="img" alt="Miniatura {{i + 1}}" />
+          </button>
+        </div>
+        <div class="main-image">
+          <div class="badges">
+            <span class="badge category" *ngIf="cuento?.categoria">{{ cuento?.categoria }}</span>
+            <span class="badge nuevo" *ngIf="badgeLabel==='Nuevo'">Nuevo</span>
+            <span class="badge top" *ngIf="badgeLabel && badgeLabel!=='Nuevo'">{{ badgeLabel }}</span>
+            <span class="badge oferta" *ngIf="hasDiscount">-{{ cuento?.descuento }}% OFF</span>
+          </div>
+          <div class="imagen-skeleton" *ngIf="cargandoImagen"></div>
+          <img
+            [appLazyLoad]="mainImage"
+            alt="Imagen del cuento"
+            (error)="cargarImagenPlaceholder($event)"
+            (load)="imagenCargada()"
+            [class.loaded]="!cargandoImagen"
+          />
+        </div>
+      </figure>
     </div>
 
   <div class="detalle-info">

--- a/src/app/components/detalle-cuento/detalle-cuento.component.scss
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.scss
@@ -20,8 +20,21 @@
 }
 
 .hero {
-  position: relative;
   width: 100%;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  align-items: center;
+}
+
+.galeria {
+  display: flex;
+  margin: 0;
+}
+
+.main-image {
+  position: relative;
+  flex: 1;
   height: 40vh;
   overflow: hidden;
 
@@ -29,6 +42,32 @@
     width: 100%;
     height: 100%;
     object-fit: cover;
+  }
+}
+
+.thumbnails {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  button {
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+
+    img {
+      width: 60px;
+      height: 60px;
+      object-fit: cover;
+      border-radius: 4px;
+      opacity: 0.6;
+    }
+
+    &.active img {
+      opacity: 1;
+      outline: 2px solid #ffad60;
+    }
   }
 }
 
@@ -341,6 +380,21 @@
     flex-direction: column;
   }
 
+  .hero {
+    flex-direction: column;
+  }
+
+  .main-image {
+    order: 1;
+    height: auto;
+  }
+
+  .thumbnails {
+    flex-direction: row;
+    order: 2;
+    justify-content: center;
+  }
+
   .portada-container {
     height: 300px;
   }
@@ -353,6 +407,11 @@
 @media (max-width: 600px) {
   .detalle-info {
     padding: 15px;
+  }
+
+  .thumbnails img {
+    width: 48px;
+    height: 48px;
   }
 
   .detalle-info h1 {

--- a/src/app/components/detalle-cuento/detalle-cuento.component.ts
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.ts
@@ -22,6 +22,7 @@ export class DetalleCuentoComponent implements OnInit {
   minFreeShipping = environment.minFreeShipping;
   isNuevo = false;
   badgeLabel = '';
+  selectedImageIndex = 0;
   /** Indica si el cuento posee un descuento válido */
   get hasDiscount(): boolean {
     return this.cuento?.descuento !== undefined && this.cuento.descuento > 0;
@@ -63,6 +64,19 @@ export class DetalleCuentoComponent implements OnInit {
   }
   imagenCargada(): void {
     this.cargandoImagen = false; // 🔥 Cuando la imagen carga, quitamos skeleton
+  }
+
+  selectImage(index: number): void {
+    this.selectedImageIndex = index;
+    this.cargandoImagen = true;
+  }
+
+  get mainImage(): string {
+    return (
+      this.cuento?.galeria?.[this.selectedImageIndex] ||
+      this.cuento?.imagenUrl ||
+      'assets/placeholder-cuento.jpg'
+    );
   }
 
   toggleTech(): void {

--- a/src/app/model/cuento.model.ts
+++ b/src/app/model/cuento.model.ts
@@ -23,4 +23,6 @@ export interface Cuento {
   descuento?: number;
   /** Indica si el cuento califica para envío gratis */
   envioGratis?: boolean;
+  /** Galería de imágenes adicionales */
+  galeria?: string[];
 }


### PR DESCRIPTION
## Summary
- extend `Cuento` model with optional `galeria` array
- track selected gallery image in `DetalleCuentoComponent`
- render main image with selectable thumbnails
- style gallery layout for desktop and mobile

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cfa36abf08327889b882b5e2ba929