### PR TITLE
Improve accessibility of detail page

### DIFF
--- a/src/app/components/admin-drawer/admin-drawer.component.html
+++ b/src/app/components/admin-drawer/admin-drawer.component.html
@@ -6,4 +6,4 @@
     </a>
   </nav>
 </aside>
-<div class="backdrop" *ngIf="isOpen" (click)="closed.emit()"></div>
+<button class="backdrop" *ngIf="isOpen" (click)="closed.emit()" aria-label="Cerrar menú"></button>

--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -7,14 +7,17 @@
         <span class="badge top" *ngIf="badgeLabel && badgeLabel!=='Nuevo'">{{ badgeLabel }}</span>
         <span class="badge oferta" *ngIf="hasDiscount">-{{ cuento?.descuento }}% OFF</span>
       </div>
-      <div class="imagen-skeleton" *ngIf="cargandoImagen"></div>
-      <img
-        [appLazyLoad]="cuento?.imagenUrl || 'assets/placeholder-cuento.jpg'"
-        alt="Imagen del cuento"
-        (error)="cargarImagenPlaceholder($event)"
-        (load)="imagenCargada()"
-        [class.loaded]="!cargandoImagen"
-      />
+      <figure>
+        <div class="imagen-skeleton" *ngIf="cargandoImagen"></div>
+        <img
+          [appLazyLoad]="cuento?.imagenUrl || 'assets/placeholder-cuento.jpg'"
+          alt="Imagen del cuento"
+          (error)="cargarImagenPlaceholder($event)"
+          (load)="imagenCargada()"
+          [class.loaded]="!cargandoImagen"
+        />
+        <figcaption class="visually-hidden">{{ cuento?.titulo }}</figcaption>
+      </figure>
     </div>
 
   <div class="detalle-info">

--- a/src/app/components/drawer-menu/drawer-menu.component.html
+++ b/src/app/components/drawer-menu/drawer-menu.component.html
@@ -54,4 +54,4 @@
     <span class="badge" *ngIf="itemCount > 0">{{ itemCount }}</span>
   </button>
 </div>
-<div class="drawer-backdrop" [class.show]="drawer.isOpen$ | async" (click)="close()"></div>
+<button class="drawer-backdrop" [class.show]="drawer.isOpen$ | async" (click)="close()" aria-label="Cerrar menú"></button>

--- a/src/app/components/mini-cart/mini-cart.component.html
+++ b/src/app/components/mini-cart/mini-cart.component.html
@@ -3,7 +3,7 @@
   <span class="badge" *ngIf="totalQuantity > 0">{{ totalQuantity }}</span>
 </button>
 
-<div class="backdrop" [class.show]="open" (click)="closeCart()"></div>
+<button class="backdrop" [class.show]="open" (click)="closeCart()" aria-label="Cerrar carrito"></button>
 <aside class="drawer mini-cart" [class.open]="open" role="dialog" aria-modal="true">
   <header class="drawer-header">
     <h3 tabindex="0">Mi carrito</h3>

--- a/src/app/components/navbar/navbar.component.html
+++ b/src/app/components/navbar/navbar.component.html
@@ -31,8 +31,10 @@
     <li *ngIf="!user">
       <button class="btn-login" (click)="openLoginDialog()">Mi cuenta</button>
     </li>
-    <li *ngIf="user?.nombre" class="avatar-wrapper" (click)="togglePerfil()">
-      <div class="avatar" [attr.title]="user?.nombre">{{ user?.nombre?.charAt(0) }}</div>
+    <li *ngIf="user?.nombre" class="avatar-wrapper">
+      <button class="avatar-btn" (click)="togglePerfil()" [attr.aria-expanded]="mostrarPerfil" aria-haspopup="true">
+        <div class="avatar" [attr.title]="user?.nombre">{{ user?.nombre?.charAt(0) }}</div>
+      </button>
       <ul class="perfil-menu" *ngIf="mostrarPerfil">
         <li><a routerLink="/perfil">Mi perfil</a></li>
         <li><a routerLink="/direcciones">Direcciones</a></li>

--- a/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
+++ b/src/app/components/pages/admin/admin-pedidos/admin-pedidos.component.html
@@ -104,7 +104,7 @@
       <button class="btn btn-warn" (click)="rechazarPago()" [disabled]="processing">Rechazar Pago</button>
     </div>
   </div>
-  <div class="drawer-backdrop show" (click)="cerrarModal()"></div>
+  <button class="drawer-backdrop show" (click)="cerrarModal()" aria-label="Cerrar modal"></button>
 </div>
 
 <app-input-dialog

--- a/src/app/components/pages/voucher/voucher.component.html
+++ b/src/app/components/pages/voucher/voucher.component.html
@@ -37,5 +37,5 @@
       </button>
     </div>
   </div>
-  <div class="drawer-backdrop show" (click)="onClose()"></div>
+  <button class="drawer-backdrop show" (click)="onClose()" aria-label="Cerrar"></button>
 </div>

--- a/src/app/services/theme.service.ts
+++ b/src/app/services/theme.service.ts
@@ -13,36 +13,42 @@ export class ThemeService {
       "--btn-primary-text": "#ffffff",
       "--btn-secondary-bg": "#ffad60",
       "--btn-secondary-text": "#ffffff",
-      "--btn-ghost-border": "#a66e38",
-      "--btn-ghost-text": "#a66e38",
+      "--btn-ghost-border": "#3f2a14",
+      "--btn-ghost-text": "#3f2a14",
       "--btn-tertiary-bg": "#96ceb4",
       "--btn-tertiary-text": "#ffffff",
       "--btn-disabled-bg": "#eeeeee",
-      "--btn-disabled-text": "#aaaaaa"
+      "--btn-disabled-text": "#aaaaaa",
+      "--bg-color": "#fffefc",
+      "--text-color": "#3f2a14"
     },
     "2": {
       "--btn-primary-bg": "#96ceb4",
       "--btn-primary-text": "#ffffff",
       "--btn-secondary-bg": "#ffad60",
       "--btn-secondary-text": "#ffffff",
-      "--btn-ghost-border": "#96ceb4",
-      "--btn-ghost-text": "#96ceb4",
+      "--btn-ghost-border": "#3f2a14",
+      "--btn-ghost-text": "#3f2a14",
       "--btn-tertiary-bg": "#a66e38",
       "--btn-tertiary-text": "#ffffff",
       "--btn-disabled-bg": "#f7f4e9",
-      "--btn-disabled-text": "#cccccc"
+      "--btn-disabled-text": "#cccccc",
+      "--bg-color": "#fffefc",
+      "--text-color": "#3f2a14"
     },
     "3": {
       "--btn-primary-bg": "#ffad60",
       "--btn-primary-text": "#ffffff",
       "--btn-secondary-bg": "#ffeead",
       "--btn-secondary-text": "#a66e38",
-      "--btn-ghost-border": "#ffad60",
-      "--btn-ghost-text": "#ffad60",
+      "--btn-ghost-border": "#3f2a14",
+      "--btn-ghost-text": "#3f2a14",
       "--btn-tertiary-bg": "#96ceb4",
       "--btn-tertiary-text": "#ffffff",
       "--btn-disabled-bg": "#faf5e0",
-      "--btn-disabled-text": "#bbbbbb"
+      "--btn-disabled-text": "#bbbbbb",
+      "--bg-color": "#fffefc",
+      "--text-color": "#3f2a14"
     }
   };
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -8,12 +8,14 @@
   --btn-primary-text: #ffffff;
   --btn-secondary-bg: #ffad60;
   --btn-secondary-text: #ffffff;
-  --btn-ghost-border: #a66e38;
-  --btn-ghost-text: #a66e38;
+  --btn-ghost-border: #3f2a14;
+  --btn-ghost-text: #3f2a14;
   --btn-tertiary-bg: #96ceb4;
   --btn-tertiary-text: #ffffff;
   --btn-disabled-bg: #eeeeee;
   --btn-disabled-text: #aaaaaa;
+  --bg-color: #fffefc;
+  --text-color: #3f2a14;
 }
 
 html, body { height: 100%; }
@@ -24,8 +26,8 @@ body {
   font-family: 'Poppins', sans-serif;
   margin: 0;
   padding: 0;
-  background-color: #fffefc;
-  color: #333;
+  background-color: var(--bg-color);
+  color: var(--text-color);
 }
 * {
   box-sizing: border-box;


### PR DESCRIPTION
## Summary
- wrap cuento image in `<figure>`/`<figcaption>`
- convert overlay divs and avatar to accessible buttons
- tweak button palette for better contrast
- update theme service palettes

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cfa46bf28832782a4ca23392023e8