### PR TITLE
Update stock messaging and rating location

### DIFF
--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -19,6 +19,10 @@
 
   <div class="detalle-info">
     <h1>{{ cuento?.titulo }}</h1>
+    <div class="rating" *ngIf="cuento?.rating != null" [attr.aria-label]="(cuento?.rating ?? 0) + ' de 5'">
+      <span class="stars">{{ getRatingStars(cuento?.rating ?? 0) }}</span>
+      <span class="count" *ngIf="cuento?.ratingCount as rc">({{ rc }})</span>
+    </div>
     <div class="autor-precio">
       <h3>Autor: {{ cuento?.autor }}</h3>
       <div class="precio">
@@ -30,14 +34,10 @@
       <span class="edad" *ngIf="cuento?.edadRecomendada">Edad: {{ cuento?.edadRecomendada }}+</span>
       <span class="envio" *ngIf="cuento?.envioGratis">🚚 Envío gratis desde S/ {{ minFreeShipping }}</span>
     </div>
-    <div class="rating" *ngIf="cuento?.rating != null" [attr.aria-label]="(cuento?.rating ?? 0) + ' de 5'">
-      <span class="stars">{{ getRatingStars(cuento?.rating ?? 0) }}</span>
-      <span class="count" *ngIf="cuento?.ratingCount as rc">({{ rc }})</span>
-    </div>
     <blockquote class="testimonial">
       “Un viaje mágico para toda la familia” – Carla R.
     </blockquote>
-    <p class="stock" [ngClass]="{ 'low-stock': lowStock }">{{ stockMessage }}</p>
+    <p class="stock" [ngClass]="lowStock ? 'low-stock' : 'en-stock'">{{ stockMessage }}</p>
     <p class="descripcion">{{ cuento?.descripcionCorta }}</p>
 
     <button class="tech-toggle" (click)="toggleTech()" aria-controls="tech-panel" [attr.aria-expanded]="openTech">Ficha técnica</button>

--- a/src/app/components/detalle-cuento/detalle-cuento.component.scss
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.scss
@@ -189,14 +189,16 @@
   margin: 2px 0;
 }
 
-.stock.low-stock {
-  color: #dc6a6a;
+.stock {
   font-weight: 600;
-}
 
-.stock.low-stock {
-  color: #dc6a6a;
-  font-weight: 600;
+  &.en-stock {
+    color: #28a745; /* green */
+  }
+
+  &.low-stock {
+    color: #ff9800; /* orange */
+  }
 }
 
 .acciones {

--- a/src/app/components/detalle-cuento/detalle-cuento.component.ts
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.ts
@@ -114,9 +114,7 @@ export class DetalleCuentoComponent implements OnInit {
     if (!this.cuento.habilitado) {
       return 'Sin stock';
     }
-    return this.cuento.stock <= 5
-      ? `¡Solo ${this.cuento.stock} unidades disponibles!`
-      : `Stock: ${this.cuento.stock}`;
+    return this.lowStock ? 'Últimas unidades' : 'En stock';
   }
 
   /** Indica si el cuento tiene pocas unidades disponibles */


### PR DESCRIPTION
## Summary
- move rating block below the title
- show stock state as *En stock* or *Últimas unidades*
- style stock states with green/orange colors

## Testing
- `npm test -- -s` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cfa4b6db48327a1b6dfb6f19572c2