### PR TITLE
Add tabs on cuento detail page

### DIFF
--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -38,15 +38,49 @@
       “Un viaje mágico para toda la familia” – Carla R.
     </blockquote>
     <p class="stock" [ngClass]="{ 'low-stock': lowStock }">{{ stockMessage }}</p>
-    <p class="descripcion">{{ cuento?.descripcionCorta }}</p>
-
-    <button class="tech-toggle" (click)="toggleTech()" aria-controls="tech-panel" [attr.aria-expanded]="openTech">Ficha técnica</button>
-    <div class="extra-info" id="tech-panel" [hidden]="!openTech">
-      <p><strong>Editorial:</strong> {{ cuento?.editorial }}</p>
-      <p><strong>Tipo de Edición:</strong> {{ cuento?.tipoEdicion }}</p>
-      <p><strong>Páginas:</strong> {{ cuento?.nroPaginas }}</p>
-      <p><strong>Publicado en:</strong> {{ cuento?.fechaPublicacion | date }}</p>
-      <p><strong>Edad Recomendada:</strong> {{ cuento?.edadRecomendada }}</p>
+    <div class="tab-container">
+      <div class="tab-headers" role="tablist">
+        <button
+          class="tab"
+          role="tab"
+          [class.active]="selectedTab === 'description'"
+          [attr.aria-selected]="selectedTab === 'description'"
+          (click)="selectTab('description')"
+        >
+          Descripción
+        </button>
+        <button
+          class="tab"
+          role="tab"
+          [class.active]="selectedTab === 'tech'"
+          [attr.aria-selected]="selectedTab === 'tech'"
+          (click)="selectTab('tech')"
+        >
+          Ficha técnica
+        </button>
+        <button
+          class="tab"
+          role="tab"
+          [class.active]="selectedTab === 'reviews'"
+          [attr.aria-selected]="selectedTab === 'reviews'"
+          (click)="selectTab('reviews')"
+        >
+          Opiniones
+        </button>
+      </div>
+      <div class="tab-panel" role="tabpanel" [hidden]="selectedTab !== 'description'">
+        <p class="descripcion">{{ cuento?.descripcionCorta }}</p>
+      </div>
+      <div class="tab-panel" role="tabpanel" [hidden]="selectedTab !== 'tech'">
+        <p><strong>Editorial:</strong> {{ cuento?.editorial }}</p>
+        <p><strong>Tipo de Edición:</strong> {{ cuento?.tipoEdicion }}</p>
+        <p><strong>Páginas:</strong> {{ cuento?.nroPaginas }}</p>
+        <p><strong>Publicado en:</strong> {{ cuento?.fechaPublicacion | date }}</p>
+        <p><strong>Edad Recomendada:</strong> {{ cuento?.edadRecomendada }}</p>
+      </div>
+      <div class="tab-panel" role="tabpanel" [hidden]="selectedTab !== 'reviews'">
+        <p>Aún no hay reseñas.</p>
+      </div>
     </div>
 
     <div class="acciones">

--- a/src/app/components/detalle-cuento/detalle-cuento.component.scss
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.scss
@@ -240,13 +240,33 @@
   color: #666;
 }
 
-.tech-toggle {
+
+.tab-container {
   margin-top: 1rem;
-  background: none;
-  border: none;
-  color: #a66e38;
-  cursor: pointer;
-  text-decoration: underline;
+
+  .tab-headers {
+    display: flex;
+    gap: 0.5rem;
+
+    .tab {
+      background: none;
+      border: none;
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+      color: #5d4037;
+      border-bottom: 2px solid transparent;
+    }
+
+    .tab.active {
+      border-color: #ffad60;
+      color: #a66e38;
+      font-weight: 600;
+    }
+  }
+
+  .tab-panel {
+    padding: 0.5rem 0;
+  }
 }
 
 .relacionados {

--- a/src/app/components/detalle-cuento/detalle-cuento.component.ts
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.ts
@@ -17,7 +17,7 @@ export class DetalleCuentoComponent implements OnInit {
   cuento?: Cuento;
   cargandoImagen: boolean = true; // 🔥 Nueva bandera para el skeleton
   relatedCuentos: Cuento[] = [];
-  openTech = false;
+  selectedTab: 'description' | 'tech' | 'reviews' = 'description';
   @ViewChild('carousel', { static: false }) carousel?: ElementRef<HTMLDivElement>;
   minFreeShipping = environment.minFreeShipping;
   isNuevo = false;
@@ -65,8 +65,8 @@ export class DetalleCuentoComponent implements OnInit {
     this.cargandoImagen = false; // 🔥 Cuando la imagen carga, quitamos skeleton
   }
 
-  toggleTech(): void {
-    this.openTech = !this.openTech;
+  selectTab(tab: 'description' | 'tech' | 'reviews'): void {
+    this.selectedTab = tab;
   }
 
   scrollCarousel(direction: number) {


### PR DESCRIPTION
## Summary
- implement tabs in cuento detail view
- track active tab in component
- style active tab with SCSS

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cfa5c56cc8327b71316d55c2b9239