### PR TITLE
Add quantity selector and responsive sticky CTA

### DIFF
--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -100,7 +100,13 @@
   </section>
   <div class="sticky-cta" *ngIf="cuento">
     <span class="price">S/ {{ precioFinal | number:'1.2-2' }}</span>
+    <div class="quantity">
+      <button type="button" (click)="decrementarCantidad()" [disabled]="cantidad <= 1">-</button>
+      <span class="amount">{{ cantidad }}</span>
+      <button type="button" (click)="incrementarCantidad()" [disabled]="cuento && cantidad >= cuento.stock">+</button>
+    </div>
     <button class="btn btn-primary" (click)="agregarAlCarrito(); $event.stopPropagation()" [disabled]="!cuento.habilitado">Añadir al carrito</button>
+    <button class="btn btn-secondary" (click)="comprarAhora(); $event.stopPropagation()" [disabled]="!cuento.habilitado">Comprar ahora</button>
   </div>
 </div>
 

--- a/src/app/components/detalle-cuento/detalle-cuento.component.scss
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.scss
@@ -396,6 +396,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 0.5rem;
 }
 
 .sticky-cta .price {
@@ -404,8 +405,34 @@
   color: #5d4037;
 }
 
+.sticky-cta .quantity {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sticky-cta .quantity button {
+  width: 32px;
+  height: 32px;
+  border: 1px solid #ccc;
+  background: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.sticky-cta .quantity .amount {
+  min-width: 24px;
+  text-align: center;
+}
+
 .sticky-cta .btn {
   width: auto;
+}
+
+@media (min-width: 769px) {
+  .sticky-cta {
+    display: none;
+  }
 }
 
 /* Responsive */

--- a/src/app/components/detalle-cuento/detalle-cuento.component.ts
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.ts
@@ -18,6 +18,8 @@ export class DetalleCuentoComponent implements OnInit {
   cargandoImagen: boolean = true; // 🔥 Nueva bandera para el skeleton
   relatedCuentos: Cuento[] = [];
   openTech = false;
+  /** Cantidad seleccionada para agregar al carrito */
+  cantidad = 1;
   @ViewChild('carousel', { static: false }) carousel?: ElementRef<HTMLDivElement>;
   minFreeShipping = environment.minFreeShipping;
   isNuevo = false;
@@ -53,7 +55,26 @@ export class DetalleCuentoComponent implements OnInit {
   }
   agregarAlCarrito() {
     if (this.cuento) {
-      this.carritoService.addItem(this.cuento);
+      this.carritoService.addItemCantidad(this.cuento, this.cantidad);
+    }
+  }
+
+  comprarAhora() {
+    if (this.cuento) {
+      this.carritoService.addItemCantidad(this.cuento, this.cantidad);
+      this.router.navigate(['/checkout']);
+    }
+  }
+
+  incrementarCantidad() {
+    if (this.cuento && this.cantidad < this.cuento.stock) {
+      this.cantidad++;
+    }
+  }
+
+  decrementarCantidad() {
+    if (this.cantidad > 1) {
+      this.cantidad--;
     }
   }
   cargarImagenPlaceholder(event: Event): void {

--- a/src/app/services/carrito.service.ts
+++ b/src/app/services/carrito.service.ts
@@ -39,6 +39,20 @@ export class CartService {
     this.toast.show(`"${cuento.titulo}" agregado al carrito`);
   }
 
+  /**
+   * Agrega un cuento al carrito con la cantidad indicada
+   */
+  addItemCantidad(cuento: Cuento, cantidad: number): void {
+    const itemExistente = this.items.find(item => item.cuento.id === cuento.id);
+    if (itemExistente) {
+      itemExistente.cantidad += cantidad;
+    } else {
+      this.items.push({ cuento, cantidad });
+    }
+    this.actualizarCarrito();
+    this.toast.show(`"${cuento.titulo}" agregado al carrito`);
+  }
+
   actualizarCarrito(): void {
     this.itemsSubject.next(this.items);
     localStorage.setItem('carrito', JSON.stringify(this.items));
@@ -56,5 +70,4 @@ export class CartService {
 
   private saveCart(): void {
     localStorage.setItem(this.cartKey, JSON.stringify(this.items));
-  }
-}
+  }}


### PR DESCRIPTION
## Summary
- allow adding multiple items with `addItemCantidad`
- show a mobile-only sticky CTA with quantity selector and optional buy-now button

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686d009e57e08327b0f54c8defdd9e8e