### PR TITLE
Improve admin dashboard layout

### DIFF
--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.html
@@ -1,47 +1,40 @@
 <div class="dashboard-content">
   <h2>Bienvenido, Admin!</h2>
 
-  <img src="/assets/libros_killa.png" appLazyLoad="assets/libros_killa.png" alt="Banner" class="dashboard-banner" />
-
   <div *ngIf="errorMensaje" class="error-mensaje">
     <p>{{ errorMensaje }}</p>
     <button (click)="onRangeChange()">Reintentar</button>
   </div>
 
-  <select [(ngModel)]="selectedDays" (change)="onRangeChange()">
-    <option [value]="7">Últimos 7 días</option>
-    <option [value]="30">Últimos 30 días</option>
-    <option [value]="90">Últimos 90 días</option>
-    <option [value]="'12m'">Últimos 12 meses</option>
-  </select>
-
-  <section class="stats-grid" aria-labelledby="stats-heading">
-    <h3 id="stats-heading" class="visually-hidden">Estadísticas</h3>
-
-    <ng-container *ngIf="isLoading">
-      <div class="stat-card skeleton" *ngFor="let s of [1,2,3]"></div>
-    </ng-container>
-
-    <ng-container *ngIf="!isLoading && !errorMensaje">
-      <app-stat-card [title]="'Cuentos publicados'" [value]="cuentosPublicados" [data]="cuentosData" [options]="sparklineOptions"></app-stat-card>
-      <app-stat-card [title]="'Pedidos en proceso'" [value]="pedidosEnProceso" [data]="pedidosData" [options]="sparklineOptions"></app-stat-card>
-      <app-stat-card [title]="'Usuarios registrados'" [value]="usuariosRegistrados" [data]="usuariosData" [options]="sparklineOptions"></app-stat-card>
-    </ng-container>
+  <section class="summary-row" aria-label="Resumen ejecutivo" *ngIf="!isLoading">
+    <app-stat-card icon="💰" [title]="'Ventas totales'" [value]="ventasTotales | currency:'PEN':'symbol'" ></app-stat-card>
+    <app-stat-card icon="🛒" [title]="'Pedidos nuevos'" [value]="pedidosNuevos" ></app-stat-card>
+    <app-stat-card icon="💳" [title]="'Ticket promedio'" [value]="ticketPromedio | number:'1.0-2'" ></app-stat-card>
+    <app-stat-card icon="🎯" [title]="'Conversión'" [value]="tasaConversion + '%'" ></app-stat-card>
   </section>
 
-  <section class="orders-stats" *ngIf="!isLoading && !errorMensaje">
-    <app-order-stats></app-order-stats>
+  <section class="charts-row" *ngIf="!isLoading">
+    <div class="chart-container">
+      <label for="periodo">Periodo:</label>
+      <select id="periodo" [(ngModel)]="selectedDays" (change)="onRangeChange()">
+        <option [value]="7">Hoy y 6 días</option>
+        <option [value]="30">Últimos 30 días</option>
+        <option [value]="90">Últimos 90 días</option>
+        <option [value]="'12m'">12 meses</option>
+      </select>
+      <canvas baseChart [data]="ingresosData" [options]="chartOptions" chartType="line"></canvas>
+    </div>
+    <div class="chart-container">
+      <canvas baseChart [data]="funnelData" [options]="chartOptions" chartType="bar"></canvas>
+    </div>
   </section>
 
-  <section class="users-section" *ngIf="!isLoading && !errorMensaje">
-    <h3>Usuarios registrados</h3>
-    <div class="users-grid">
-      <div class="user-card" *ngFor="let user of usuarios">
-        <p class="user-name">{{ user.nombre }} {{ user.apellido }}</p>
-        <p class="user-email">{{ user.email }}</p>
-        <p class="user-phone">{{ user.telefono }}</p>
-        <p class="user-role">{{ user.role }}</p>
-      </div>
+  <section class="status-row" *ngIf="!isLoading">
+    <h3>Estado de pedidos <button routerLink="/admin/pedidos" class="btn btn-link">Ver lista</button></h3>
+    <div class="status-bar" *ngFor="let s of statusKeys">
+      <span class="label">{{ s }}</span>
+      <div class="bar"><span [style.width.%]="statusCounts[s] * 5"></span></div>
+      <span class="count">{{ statusCounts[s] || 0 }}</span>
     </div>
   </section>
 </div>

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.scss
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.scss
@@ -2,148 +2,58 @@
   padding: 1.5rem;
   background-color: #FEF6E8;
   color: #4E3B15;
+}
 
-  h2 {
-    font-size: 24px;
-    font-weight: bold;
-    color: #38290F;
-    margin-bottom: 1rem;
+.summary-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.charts-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.chart-container {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+.status-row {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+}
+
+.status-bar {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.5rem;
+  .label {
+    width: 120px;
   }
-
-  .dashboard-banner {
-    max-height: 200px;
-    width: 100%;
-    object-fit: cover;
-    border-radius: 8px;
-    margin-bottom: 1rem;
-  }
-
-  .stats-grid {
-    display: grid;
-    grid-gap: 1rem;
-    grid-template-columns: 1fr;
-    @media (min-width: 768px) {
-      grid-template-columns: repeat(2, 1fr);
-    }
-    @media (min-width: 1024px) {
-      grid-template-columns: repeat(3, 1fr);
-    }
-    @media (min-width: 1280px) {
-      grid-template-columns: repeat(4, 1fr);
-    }
-  }
-
-  .stat-card {
-    background: #fff;
-    border-radius: 8px;
-    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-    padding: 1rem;
-    text-align: center;
-
-    .value {
+  .bar {
+    flex: 1;
+    background: #eee;
+    height: 12px;
+    margin: 0 0.5rem;
+    border-radius: 6px;
+    overflow: hidden;
+    span {
       display: block;
-      font-size: 24px;
-      font-weight: bold;
-      color: #a66e38;
-      margin-bottom: .25rem;
-    }
-
-    .label {
-      color: #704b26;
-      font-size: 14px;
+      height: 100%;
+      background: #FFAD60;
     }
   }
-
-  .skeleton {
-    background: #e0e0e0;
-    height: 100px;
-    border-radius: 4px;
+  .count {
+    width: 30px;
+    text-align: right;
   }
-
-  .loading-indicator {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    padding: 2rem 0;
-
-    .spinner {
-      border: 4px solid #f3f3f3;
-      border-top: 4px solid #a66e38;
-      border-radius: 50%;
-      width: 40px;
-      height: 40px;
-      animation: spin 1s linear infinite;
-    }
-  }
-
-  .error-mensaje {
-    text-align: center;
-    background: #ffd3d3;
-    padding: 1rem;
-    border-radius: 8px;
-    margin-bottom: 1rem;
-
-    p {
-      margin: 0 0 0.5rem 0;
-    }
-
-    button {
-      background: #a66e38;
-      color: #fff;
-      border: none;
-      padding: 0.5rem 1rem;
-      border-radius: 4px;
-      cursor: pointer;
-    }
-  }
-
-  .users-section {
-    margin-top: 2rem;
-
-    h3 {
-      margin-bottom: 1rem;
-      font-size: 20px;
-      color: #38290F;
-    }
-
-    .users-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-      gap: 1rem;
-    }
-
-    .user-card {
-      background: #fff;
-      border-radius: 8px;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-      padding: 1rem;
-
-      .user-name {
-        font-weight: 600;
-        color: #a66e38;
-      }
-
-      p {
-        margin: 0.25rem 0;
-        font-size: 14px;
-        color: #704b26;
-      }
-    }
-  }
-}
-
-@media (max-width: 768px) {
-  .stats-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .users-section {
-    .users-grid {
-      grid-template-columns: 1fr;
-    }
-  }
-}
-
-@keyframes spin {
-  100% { transform: rotate(360deg); }
 }

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.spec.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.component.spec.ts
@@ -41,7 +41,22 @@ describe('AdminDashboardComponent', () => {
 
   it('should update counters with data from services', () => {
     cuentoServiceSpy.obtenerCuentos.and.returnValue(of([{} as Cuento, {} as Cuento]));
-    pedidoServiceSpy.getOrders.and.returnValue(of([{} as Pedido]));
+    pedidoServiceSpy.getOrders.and.returnValue(of([
+      {
+        Id: 1,
+        id: 1,
+        fecha: new Date().toISOString(),
+        nombre: '',
+        correo: '',
+        direccion: '',
+        telefono: '',
+        items: [],
+        total: 10,
+        estado: 'PAGO_PENDIENTE',
+        userId: 1,
+        correoUsuario: ''
+      } as Pedido
+    ]));
     userServiceSpy.obtenerUsuarios.and.returnValue(of([{} as User, {} as User, {} as User]));
 
     fixture.detectChanges();
@@ -49,10 +64,8 @@ describe('AdminDashboardComponent', () => {
     expect(component.cuentosPublicados).toBe(2);
     expect(component.pedidosEnProceso).toBe(1);
     expect(component.usuariosRegistrados).toBe(3);
-    expect(component.usuarios.length).toBe(3);
-    expect(component.cuentosData.length).toBeGreaterThanOrEqual(5);
-    expect(component.pedidosData.length).toBeGreaterThanOrEqual(5);
-    expect(component.usuariosData.length).toBeGreaterThanOrEqual(5);
+    expect(component.pedidosNuevos).toBe(1);
+    expect(component.ventasTotales).toBe(0);
     expect(component.isLoading).toBeFalse();
     expect(component.errorMensaje).toBeNull();
   });

--- a/src/app/components/pages/admin/admin-dashboard/admin-dashboard.module.ts
+++ b/src/app/components/pages/admin/admin-dashboard/admin-dashboard.module.ts
@@ -5,14 +5,13 @@ import { RouterModule, Routes } from '@angular/router';
 import { NgChartsModule } from 'ng2-charts';
 import { AdminDashboardComponent } from './admin-dashboard.component';
 import { StatCardComponent } from '../../../stat-card/stat-card.component';
-import { OrderStatsComponent } from '../../../order-stats/order-stats.component';
 
 const routes: Routes = [
   { path: '', component: AdminDashboardComponent }
 ];
 
 @NgModule({
-  declarations: [AdminDashboardComponent, OrderStatsComponent],
+  declarations: [AdminDashboardComponent],
   imports: [CommonModule, FormsModule, NgChartsModule, RouterModule.forChild(routes), StatCardComponent],
   exports: [AdminDashboardComponent]
 })

--- a/src/app/components/stat-card/stat-card.component.ts
+++ b/src/app/components/stat-card/stat-card.component.ts
@@ -12,7 +12,7 @@ import { ChartOptions } from 'chart.js';
 })
 export class StatCardComponent {
   @Input() title = '';
-  @Input() value: number | string = 0;
+  @Input() value: number | string | null = 0;
   @Input() data: number[] = [];
   @Input() icon = '';
   @Input() options: ChartOptions | undefined = undefined;


### PR DESCRIPTION
## Summary
- revamp admin dashboard layout with a new summary, chart and status sections
- add revenue charts and order status indicators
- simplify admin-dashboard module
- update dashboard tests
- allow `StatCardComponent` to accept null values

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d651f68e88327a12383c81139bc85