### PR TITLE
Allow HTML toast content

### DIFF
--- a/src/app/services/carrito.service.ts
+++ b/src/app/services/carrito.service.ts
@@ -36,7 +36,9 @@ export class CartService {
       this.items.push({ cuento, cantidad });
     }
     this.actualizarCarrito();
-    this.toast.show(`"${cuento.titulo}" agregado al carrito`);
+    this.toast.show(
+      `"${cuento.titulo}" agregado al carrito. <a href="/carrito">Ver carrito</a>`
+    );
   }
 
   /**

--- a/src/app/services/toast.service.ts
+++ b/src/app/services/toast.service.ts
@@ -10,7 +10,7 @@ export class ToastService {
   }
 
   show(
-    message: string,
+    content: string | Node | ((toast: HTMLElement) => void),
     type: 'success' | 'warning' | 'error' | 'info' = 'info'
   ): void {
     if (!this.container) {
@@ -19,7 +19,15 @@ export class ToastService {
 
     const toast = this.document.createElement('div');
     toast.className = `alert alert--${type}`;
-    toast.textContent = message;
+
+    if (typeof content === 'function') {
+      content(toast);
+    } else if (typeof content === 'string') {
+      toast.innerHTML = content;
+    } else {
+      toast.appendChild(content);
+    }
+
     this.container.appendChild(toast);
     setTimeout(() => toast.remove(), 2000);
   }


### PR DESCRIPTION
## Summary
- expand `ToastService.show` to support HTML and callbacks
- add cart link to toast when adding an item

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7ef2db30832798ffcb6fad6045ca