### PR TITLE
Add navigation for related stories

### DIFF
--- a/src/app/components/detalle-cuento/detalle-cuento.component.html
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.html
@@ -145,7 +145,7 @@
       <button class="prev" aria-label="Anterior" (click)="scrollCarousel(-1)">‹</button>
       <div class="carousel" #carousel>
         <div class="slide" *ngFor="let book of relatedCuentos">
-          <div class="card">
+          <div class="card" (click)="verDetalleCuento(book.id)">
             <img appLazyLoad="{{ book.imagenUrl || 'assets/placeholder-cuento.jpg' }}" alt="{{ book.titulo }}" class="w-full rounded-lg" />
             <p class="titulo">{{ book.titulo }}</p>
             <p class="precio">S/ {{ book.precio | number:'1.2-2' }}</p>

--- a/src/app/components/detalle-cuento/detalle-cuento.component.scss
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.scss
@@ -382,6 +382,7 @@
     padding: 0.5rem;
     text-align: center;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    cursor: pointer;
 
     img {
       width: 100%;

--- a/src/app/components/detalle-cuento/detalle-cuento.component.ts
+++ b/src/app/components/detalle-cuento/detalle-cuento.component.ts
@@ -117,6 +117,10 @@ export class DetalleCuentoComponent implements OnInit {
     }
   }
 
+  verDetalleCuento(id: number): void {
+    this.router.navigate(['/cuento', id]);
+  }
+
   compartir(red: 'whatsapp' | 'tiktok') {
     const url = encodeURIComponent(window.location.href);
     if (red === 'whatsapp') {


### PR DESCRIPTION
## Summary
- make related cuento cards clickable
- navigate to selected cuento from detail page
- tweak card hover style

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e45b4b3248327827dbf5c0745cefb