### PR TITLE
refactor: simplify shared module

### DIFF
--- a/src/app/components/shared.module.ts
+++ b/src/app/components/shared.module.ts
@@ -1,19 +1,13 @@
-import { NgModule ,CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
-import { Routes } from '@angular/router';
+import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CuentoCardComponent } from './cuento-card/cuento-card.component';
 import { LazyLoadImageDirective } from '../directives/lazy-load-image.directive';
 import { FlyToCartDirective } from '../directives/fly-to-cart.directive';
-// import { CuentosGridComponent } from './cuentos-grid/cuentos-grid.component';
-
-const routes: Routes = [
-  { path: '', component: CuentoCardComponent }
-];
 
 @NgModule({
   declarations: [CuentoCardComponent],
   imports: [CommonModule, LazyLoadImageDirective, FlyToCartDirective],
-  exports: [CuentoCardComponent, LazyLoadImageDirective, FlyToCartDirective], // 🔥 esto es clave
-  schemas: [CUSTOM_ELEMENTS_SCHEMA]
+  exports: [CuentoCardComponent, LazyLoadImageDirective, FlyToCartDirective]
 })
 export class SharedModule {}
+


### PR DESCRIPTION
## Summary
- remove unused routing setup and imports from shared module
- drop unnecessary CUSTOM_ELEMENTS_SCHEMA
- ensure file ends with newline

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless --no-progress` *(fails: Property 'cuentoId' is missing...)*

------
https://chatgpt.com/codex/tasks/task_e_6896d0403d308327b3eb786bc2642582