### PR TITLE
refactor: lazy load page components

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,26 +1,19 @@
 import { Routes } from '@angular/router';
-import { LayoutComponent } from './components/layout/layout.component'; // importa tu layout
-import { CheckoutComponent } from './components/pages/checkout/checkout.component';
-import { LoginComponent } from './components/pages/login/login.component';
-import { RegisterComponent } from './components/pages/register/register.component';
 import { authGuard } from './guards/auth.guard';
-import { PagoComponent } from './components/pages/pago/pago.component';
-import { VoucherComponent } from './components/pages/voucher/voucher.component';
-import { OrderListComponent } from './components/pages/order-list/order-list.component';
-import { OrderDetailComponent } from './components/pages/order-detail/order-detail.component';
 import { AdminGuard } from './guards/admin.guard';
 
 
 export const routes: Routes = [
   {
     path: '',
-    component: LayoutComponent,
+    loadComponent: () =>
+      import('./components/layout/layout.component').then(m => m.LayoutComponent),
     children: [
       {
         path: 'home',
         loadChildren: () =>
           import('./components/pages/Home/home.module').then((m) => m.HomeModule),
-      }, 
+      },
       {
         path: 'cuento/:id',
         loadChildren: () =>
@@ -28,23 +21,56 @@ export const routes: Routes = [
       },
       {
         path: 'carrito',
-        loadComponent: () => import('./components/cart/cart.component').then(m => m.CartComponent)
+        loadComponent: () =>
+          import('./components/cart/cart.component').then(m => m.CartComponent)
       },
-      { path: 'checkout', component: CheckoutComponent },
-      { path: 'pago/:id', component: PagoComponent },
-      { path: 'voucher/:id', component: VoucherComponent }, // si vas a subir comprobante
-      { path: 'login', component: LoginComponent },
-      { path: 'register', component: RegisterComponent },
-      { path: 'pedidos', component: OrderListComponent, canActivate: [authGuard] },
-      { path: 'pedidos/:id', component: OrderDetailComponent, canActivate: [authGuard] },
+      {
+        path: 'checkout',
+        loadComponent: () =>
+          import('./components/pages/checkout/checkout.component').then(m => m.CheckoutComponent)
+      },
+      {
+        path: 'pago/:id',
+        loadComponent: () =>
+          import('./components/pages/pago/pago.component').then(m => m.PagoComponent)
+      },
+      {
+        path: 'voucher/:id',
+        loadComponent: () =>
+          import('./components/pages/voucher/voucher.component').then(m => m.VoucherComponent)
+      }, // si vas a subir comprobante
+      {
+        path: 'login',
+        loadComponent: () =>
+          import('./components/pages/login/login.component').then(m => m.LoginComponent)
+      },
+      {
+        path: 'register',
+        loadComponent: () =>
+          import('./components/pages/register/register.component').then(m => m.RegisterComponent)
+      },
+      {
+        path: 'pedidos',
+        loadComponent: () =>
+          import('./components/pages/order-list/order-list.component').then(m => m.OrderListComponent),
+        canActivate: [authGuard]
+      },
+      {
+        path: 'pedidos/:id',
+        loadComponent: () =>
+          import('./components/pages/order-detail/order-detail.component').then(m => m.OrderDetailComponent),
+        canActivate: [authGuard]
+      },
       {
         path: 'admin',
-        loadChildren: () => import('./components/pages/admin/admin.module').then(m => m.AdminModule),
+        loadChildren: () =>
+          import('./components/pages/admin/admin.module').then(m => m.AdminModule),
         canActivate: [AdminGuard]
       },
       {
         path: 'cuentos',
-        loadChildren: () => import('./components/pages/cuentos/cuentos.module').then(m => m.CuentosModule)
+        loadChildren: () =>
+          import('./components/pages/cuentos/cuentos.module').then(m => m.CuentosModule)
       },
       {
         path: '',


### PR DESCRIPTION
## Summary
- lazy load layout and page components using `loadComponent`

## Testing
- `npm test` *(fails: Property 'cuentoId' missing in test mocks)*
- `npm run build` *(fails: Inlining of fonts failed, google fonts 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896d04914488327ae6825e2f4aa23ef