### PR TITLE
refactor auth storage

### DIFF
--- a/src/app/services/storage.service.ts
+++ b/src/app/services/storage.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+
+export const TOKEN_KEY = 'token';
+export const USER_KEY = 'userData';
+
+@Injectable({ providedIn: 'root' })
+export class StorageService {
+  setItem(key: string, value: string) {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(key, value);
+    }
+  }
+
+  getItem(key: string): string | null {
+    return typeof window !== 'undefined' ? localStorage.getItem(key) : null;
+  }
+
+  removeItem(key: string) {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem(key);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- use `BehaviorSubject` to track logged in user
- add `StorageService` to wrap `localStorage` with shared keys
- refactor AuthService to use `StorageService` and centralized keys

## Testing
- `npm test` *(fails: Property 'cuentoId' is missing...)*

------
https://chatgpt.com/codex/tasks/task_e_6896d04f87fc83279c3a6a3082813032