### PR TITLE
chore: clean auth interceptor

### DIFF
--- a/src/app/services/auth.interceptor.ts
+++ b/src/app/services/auth.interceptor.ts
@@ -1,4 +1,3 @@
-import { Injectable } from '@angular/core';
 import { HttpInterceptorFn } from '@angular/common/http';
 
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
@@ -9,8 +8,6 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
         headers: req.headers.set('Authorization', `Bearer ${token}`)
       });
       req = cloned.clone();
-      console.log('req:',req);
-      console.log('cloned:',cloned);
       return next(cloned);
     }
   }


### PR DESCRIPTION
## Summary
- remove unused import and debug logs from auth interceptor

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_6896d054de9883279a2e06859a5b3d4c