### PR TITLE
feat: add typed responses for services

### DIFF
--- a/src/app/model/api-response.model.ts
+++ b/src/app/model/api-response.model.ts
@@ -1,0 +1,3 @@
+export interface ApiResponse {
+  message: string;
+}

--- a/src/app/model/auth-response.model.ts
+++ b/src/app/model/auth-response.model.ts
@@ -1,0 +1,6 @@
+import { User } from './user.model';
+
+export interface LoginResponse {
+  token: string;
+  user: User;
+}

--- a/src/app/model/pago-response.model.ts
+++ b/src/app/model/pago-response.model.ts
@@ -1,0 +1,4 @@
+export interface PagoResponse {
+  status: string;
+  message: string;
+}

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { User } from '../model/user.model';
-import { Subject } from 'rxjs';
+import { Subject, Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
+import { LoginResponse } from '../model/auth-response.model';
 
 
 @Injectable({ providedIn: 'root' })
@@ -17,12 +18,12 @@ export class AuthService {
    
   }
 
-  login(email: string, password: string) {
-    return this.http.post<any>(`${this.apiUrl}/login`, { email, password });
+  login(email: string, password: string): Observable<LoginResponse> {
+    return this.http.post<LoginResponse>(`${this.apiUrl}/login`, { email, password });
   }
 
-  register(data: any) {
-    return this.http.post<any>(`${this.apiUrl}/register`, data);
+  register(data: any): Observable<User> {
+    return this.http.post<User>(`${this.apiUrl}/register`, data);
   }
 
   guardarToken(token: string) {

--- a/src/app/services/pago.service.ts
+++ b/src/app/services/pago.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
+import { PagoResponse } from '../model/pago-response.model';
 
 @Injectable({
   providedIn: 'root'
@@ -12,7 +13,7 @@ export class PagoService {
 
   constructor(private http: HttpClient) { }
 
-  confirmarPagoMercadoPago(pedidoId: number): Observable<any> {
-    return this.http.post<any>(`${this.apiUrl}/${pedidoId}/confirmar-pago-mercadopago`, {});
+  confirmarPagoMercadoPago(pedidoId: number): Observable<PagoResponse> {
+    return this.http.post<PagoResponse>(`${this.apiUrl}/${pedidoId}/confirmar-pago-mercadopago`, {});
   }
 }

--- a/src/app/services/pedido.service.ts
+++ b/src/app/services/pedido.service.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core';
 import { Pedido } from '../model/pedido.model';
 import { Observable } from 'rxjs';
 import { environment } from './../../environments/environment';
+import { ApiResponse } from '../model/api-response.model';
 
 @Injectable({
   providedIn: 'root'
@@ -12,16 +13,16 @@ export class PedidoService {
 
   constructor(private http: HttpClient) {}
 
-  registrarPedido(pedido: Pedido): Observable<any> {
-    return this.http.post(this.apiUrl, pedido);
+  registrarPedido(pedido: Pedido): Observable<Pedido> {
+    return this.http.post<Pedido>(this.apiUrl, pedido);
   }
 
-  uploadVoucher(pedidoId: number, voucherFile: File): Observable<any> {
+  uploadVoucher(pedidoId: number, voucherFile: File): Observable<ApiResponse> {
     const formData = new FormData();
     // Backend expects these specific field names
     formData.append('file', voucherFile);
     formData.append('idpedido', pedidoId.toString());
-    return this.http.post(`${this.apiUrl}/${pedidoId}/voucherF`, formData,{ withCredentials: true });
+    return this.http.post<ApiResponse>(`${this.apiUrl}/${pedidoId}/voucherF`, formData,{ withCredentials: true });
   }
 
   getOrderStatus(pedidoId: number): Observable<{ estado: string }> {
@@ -52,8 +53,8 @@ export class PedidoService {
    * Actualiza el estado del pedido. Opcionalmente se puede enviar un motivo
    * en caso de que el estado sea de rechazo.
    */
-  updateOrderStatus(id: number, estado: string, motivo?: string): Observable<any> {
-    return this.http.patch(
+  updateOrderStatus(id: number, estado: string, motivo?: string): Observable<ApiResponse> {
+    return this.http.patch<ApiResponse>(
       `${this.apiUrl}/${id}/status`,
       { estado, motivo },
       { withCredentials: true }


### PR DESCRIPTION
## Summary
- add auth, payment and generic API response models
- use typed observables in auth, payment and order services

## Testing
- `npx tsc -p tsconfig.app.json`
- `npm test -- --watch=false` *(fails: Property 'cuentoId' is missing in type ...)*

------
https://chatgpt.com/codex/tasks/task_e_6896d055bd04832790fa425ac8780fa7